### PR TITLE
find_package() in root scope

### DIFF
--- a/rmw_implementation/cmake/add_executable_for_each_rmw_implementation.cmake
+++ b/rmw_implementation/cmake/add_executable_for_each_rmw_implementation.cmake
@@ -37,15 +37,18 @@
 # :param INSTALL: if set install all executables
 # :type INSTALL: option
 #
-function(add_executable_for_each_rmw_implementations target)
+macro(add_executable_for_each_rmw_implementations)
+  # get available rmw implementations
+  get_available_rmw_implementations(_rmw_implementations)
+  foreach(_rmw_implementation ${_rmw_implementations})
+    find_package("${_rmw_implementation}" REQUIRED)
+  endforeach()
+  _add_executable_for_each_rmw_implementations(${ARGN})
+endmacro()
+
+function(_add_executable_for_each_rmw_implementations target)
   cmake_parse_arguments(ARG
     "INSTALL;SKIP_DEFAULT" "ALL_TARGET_NAMES_VAR" "TARGET_DEPENDENCIES" ${ARGN})
-
-  # get available rmw implementations
-  get_available_rmw_implementations(rmw_implementations)
-  foreach(rmw_implementation ${rmw_implementations})
-    find_package("${rmw_implementation}" REQUIRED)
-  endforeach()
 
   set(targets "")
   if(NOT ARG_SKIP_DEFAULT)

--- a/rmw_implementation/cmake/get_default_rmw_implementation.cmake
+++ b/rmw_implementation/cmake/get_default_rmw_implementation.cmake
@@ -21,36 +21,36 @@
 # :param var: the output variable name containing the package name
 # :type var: string
 #
-function(get_default_rmw_implementation var)
-  get_available_rmw_implementations(middleware_implementations)
+macro(get_default_rmw_implementation var)
+  get_available_rmw_implementations(_middleware_implementations)
 
-  if("${middleware_implementations} " STREQUAL " ")
+  if("${_middleware_implementations} " STREQUAL " ")
     message(FATAL_ERROR "Could not find any ROS middleware implementation.")
   endif()
 
   # option()
   if(NOT "${ROS_MIDDLEWARE_IMPLEMENTATION} " STREQUAL " ")
-    set(middleware_implementation "${ROS_MIDDLEWARE_IMPLEMENTATION}")
+    set(_middleware_implementation "${ROS_MIDDLEWARE_IMPLEMENTATION}")
   elseif(NOT "$ENV{ROS_MIDDLEWARE_IMPLEMENTATION} " STREQUAL " ")
-    set(middleware_implementation "$ENV{ROS_MIDDLEWARE_IMPLEMENTATION}")
+    set(_middleware_implementation "$ENV{ROS_MIDDLEWARE_IMPLEMENTATION}")
   else()
     # TODO detemine "default" implementation based on the available ones
-    list(GET middleware_implementations 0 middleware_implementation)
+    list(GET _middleware_implementations 0 _middleware_implementation)
   endif()
 
   # verify that the selection one is available
-  list(FIND middleware_implementations "${middleware_implementation}" _index)
+  list(FIND _middleware_implementations "${_middleware_implementation}" _index)
   if(_index EQUAL -1)
-    string(REPLACE ";" ", " middleware_implementations_string "${middleware_implementations}")
-    message(FATAL_ERROR "Could not find ROS middleware implementation '${middleware_implementation}'. Choose one of the following: ${middleware_implementations_string}")
+    string(REPLACE ";" ", " _middleware_implementations_string "${_middleware_implementations}")
+    message(FATAL_ERROR "Could not find ROS middleware implementation '${_middleware_implementation}'. Choose one of the following: ${_middleware_implementations_string}")
   endif()
-  find_package("${middleware_implementation}" REQUIRED)
+  find_package("${_middleware_implementation}" REQUIRED)
 
   # persist implementation decision in cache
   set(
-    ROS_MIDDLEWARE_IMPLEMENTATION "${middleware_implementation}"
+    ROS_MIDDLEWARE_IMPLEMENTATION "${_middleware_implementation}"
     CACHE STRING "Select ROS middleware implementation to link against" FORCE
   )
 
-  set(${var} ${middleware_implementation} PARENT_SCOPE)
-endfunction()
+  set(${var} ${_middleware_implementation})
+endmacro()


### PR DESCRIPTION
Invoke `find_package()` in the root scope (rather then in a function scope) to prevent finding the same package repeatedly. E.g. http://ci.ros2.org/job/ros2_batch_ci_linux/320/consoleFull#console-section-74

http://ci.ros2.org/job/ros2_batch_ci_linux/331/consoleFull#console-section-73