### PR TITLE
Make message clearer when specifying default rmw implementation

### DIFF
--- a/rmw_implementation/rmw_implementation-extras.cmake.in
+++ b/rmw_implementation/rmw_implementation-extras.cmake.in
@@ -44,7 +44,7 @@ endif()
 
 
 set(RMW_IMPLEMENTATION "${default_rmw_implementation}")
-message(STATUS "Using RMW implementation: ${RMW_IMPLEMENTATION}")
+message(STATUS "Using RMW implementation '${RMW_IMPLEMENTATION}' as default.")
 find_package("${RMW_IMPLEMENTATION}" REQUIRED)
 
 # TODO should never need definitions and include dirs?


### PR DESCRIPTION
it was a bit vague before about what it was doing