### PR TITLE
add messages as cmake output that displays the discovered rmw impls and the default

### DIFF
--- a/rmw_implementation/CMakeLists.txt
+++ b/rmw_implementation/CMakeLists.txt
@@ -13,6 +13,17 @@ endif()
 
 get_default_rmw_implementation(RMW_IMPLEMENTATION)
 
+get_available_rmw_implementations(impls)
+message(STATUS "")
+message(STATUS "Found these rmw implementations:")
+foreach(impl IN LISTS impls)
+  message(STATUS "  '${impl}'")
+endforeach()
+
+message(STATUS "")
+message(STATUS "Using default rmw implementation: '${RMW_IMPLEMENTATION}'")
+message(STATUS "")
+
 ament_package(
   CONFIG_EXTRAS "rmw_implementation-extras.cmake.in"
 )


### PR DESCRIPTION
Looks like this:

```
...
-- Found OpenSplice: ...
--
-- Found these rmw implementations:
--   'rmw_connext_cpp'
--   'rmw_connext_dynamic_cpp'
--   'rmw_opensplice_cpp'
--
-- Using default rmw implementation: 'rmw_opensplice_cpp'
--
-- Added test 'lint_cmake' to check CMake code style
...
```