### PR TITLE
API to enable log severity setting. 

### DIFF
--- a/rmw_implementation/src/functions.cpp
+++ b/rmw_implementation/src/functions.cpp
@@ -355,6 +355,10 @@ RMW_INTERFACE_FN(rmw_service_server_is_available,
   rmw_ret_t, RMW_RET_ERROR,
   3, ARG_TYPES(const rmw_node_t *, const rmw_client_t *, bool *))
 
+RMW_INTERFACE_FN(rmw_set_log_severity,
+  rmw_ret_t, RMW_RET_ERROR,
+  1, ARG_TYPES(const rmw_log_severity_t *))
+
 #define GET_SYMBOL(x) symbol_ ## x = get_symbol(#x);
 
 void prefetch_symbols(void)

--- a/rmw_implementation/src/functions.cpp
+++ b/rmw_implementation/src/functions.cpp
@@ -357,7 +357,7 @@ RMW_INTERFACE_FN(rmw_service_server_is_available,
 
 RMW_INTERFACE_FN(rmw_set_log_severity,
   rmw_ret_t, RMW_RET_ERROR,
-  1, ARG_TYPES(const rmw_log_severity_t *))
+  1, ARG_TYPES(rmw_log_severity_t))
 
 #define GET_SYMBOL(x) symbol_ ## x = get_symbol(#x);
 


### PR DESCRIPTION
https://github.com/ros2/rmw/pull/124/ url on rmw.

The patch enables setting log severity from userland applications. The parameter
passed is defined inside rmw/include/types.h

Signed-off-by: Sriram Raghunathan <sriram.max@gmail.com>

Connect to ros2/rmw#124