### PR TITLE
avoid recursive find

### DIFF
--- a/rmw_implementation/rmw_implementation-extras.cmake.in
+++ b/rmw_implementation/rmw_implementation-extras.cmake.in
@@ -66,13 +66,15 @@ endif()
 
 if(@RMW_IMPLEMENTATION_SUPPORTS_POCO@)
   set(selected_rmw_implementation "@PROJECT_NAME@")
+  # no need to find_package @PROJECT_NAME@
+  # since this code is already part of a find_package call of that package
 else()
   set(selected_rmw_implementation "${default_rmw_implementation}")
   message(STATUS "Using RMW implementation '${selected_rmw_implementation}' as default")
-endif()
-find_package("${selected_rmw_implementation}" REQUIRED)
+  find_package("${selected_rmw_implementation}" REQUIRED)
 
-# TODO should never need definitions and include dirs?
-list(APPEND rmw_implementation_DEFINITIONS ${${selected_rmw_implementation}_DEFINITIONS})
-list(APPEND rmw_implementation_INCLUDE_DIRS ${${selected_rmw_implementation}_INCLUDE_DIRS})
-list(APPEND rmw_implementation_LIBRARIES ${${selected_rmw_implementation}_LIBRARIES})
+  # TODO should never need definitions and include dirs?
+  list(APPEND rmw_implementation_DEFINITIONS ${${selected_rmw_implementation}_DEFINITIONS})
+  list(APPEND rmw_implementation_INCLUDE_DIRS ${${selected_rmw_implementation}_INCLUDE_DIRS})
+  list(APPEND rmw_implementation_LIBRARIES ${${selected_rmw_implementation}_LIBRARIES})
+endif()


### PR DESCRIPTION
In the case where `selected_rmw_implementation` is `rmw_implementation` it shouldn't call `find_package` for it since the entire logic already happens in the CMake config file of `rmw_implementation` so it is already "inside" a `find_package(rmw_implementation)` call.

This only doesn't end in an infinite recursion due to the custom logic in the generated CMake config files which returns early from repeated finds: https://github.com/ament/ament_cmake/blob/6d171d79584319c216e6880c46372224cd3ae6eb/ament_cmake_core/cmake/core/templates/nameConfig.cmake.in#L3-L7

Connect to ros2/ros2#544.