### PR TITLE
QoS Events and Liveliness

### DIFF
--- a/rmw_implementation/src/functions.cpp
+++ b/rmw_implementation/src/functions.cpp
@@ -29,6 +29,7 @@
 #include "Poco/SharedLibrary.h"
 
 #include "rmw/error_handling.h"
+#include "rmw/event.h"
 #include "rmw/names_and_types.h"
 #include "rmw/get_node_info_and_types.h"
 #include "rmw/get_service_names_and_types.h"
@@ -185,6 +186,7 @@ extern "C"
 #define ARG_VALUES_4(t4, ...) v4, EXPAND(ARG_VALUES_3(__VA_ARGS__))
 #define ARG_VALUES_5(t5, ...) v5, EXPAND(ARG_VALUES_4(__VA_ARGS__))
 #define ARG_VALUES_6(t6, ...) v6, EXPAND(ARG_VALUES_5(__VA_ARGS__))
+#define ARG_VALUES_7(t7, ...) v7, EXPAND(ARG_VALUES_6(__VA_ARGS__))
 
 #define ARGS_0(...) __VA_ARGS__
 #define ARGS_1(t1) t1 v1
@@ -193,6 +195,7 @@ extern "C"
 #define ARGS_4(t4, ...) t4 v4, EXPAND(ARGS_3(__VA_ARGS__))
 #define ARGS_5(t5, ...) t5 v5, EXPAND(ARGS_4(__VA_ARGS__))
 #define ARGS_6(t6, ...) t6 v6, EXPAND(ARGS_5(__VA_ARGS__))
+#define ARGS_7(t7, ...) t7 v7, EXPAND(ARGS_6(__VA_ARGS__))
 
 #define CALL_SYMBOL(symbol_name, ReturnType, error_value, ArgTypes, arg_values) \
   if (!symbol_ ## symbol_name) { \
@@ -253,6 +256,10 @@ RMW_INTERFACE_FN(rmw_destroy_node,
   rmw_ret_t, RMW_RET_ERROR,
   1, ARG_TYPES(rmw_node_t *))
 
+RMW_INTERFACE_FN(rmw_node_assert_liveliness,
+  rmw_ret_t, RMW_RET_ERROR,
+  1, ARG_TYPES(const rmw_node_t *))
+
 RMW_INTERFACE_FN(rmw_node_get_graph_guard_condition,
   const rmw_guard_condition_t *, nullptr,
   1, ARG_TYPES(const rmw_node_t *))
@@ -282,6 +289,10 @@ RMW_INTERFACE_FN(rmw_publisher_get_actual_qos,
 RMW_INTERFACE_FN(rmw_publish_serialized_message,
   rmw_ret_t, RMW_RET_ERROR,
   2, ARG_TYPES(const rmw_publisher_t *, const rmw_serialized_message_t *))
+
+RMW_INTERFACE_FN(rmw_publisher_assert_liveliness,
+  rmw_ret_t, RMW_RET_ERROR,
+  1, ARG_TYPES(const rmw_publisher_t *))
 
 RMW_INTERFACE_FN(rmw_serialize,
   rmw_ret_t, RMW_RET_ERROR,
@@ -358,6 +369,10 @@ RMW_INTERFACE_FN(rmw_send_response,
   rmw_ret_t, RMW_RET_ERROR,
   3, ARG_TYPES(const rmw_service_t *, rmw_request_id_t *, void *))
 
+RMW_INTERFACE_FN(rmw_take_event,
+  rmw_ret_t, RMW_RET_ERROR,
+  3, ARG_TYPES(const rmw_event_t *, void *, bool *))
+
 RMW_INTERFACE_FN(rmw_create_guard_condition,
   rmw_guard_condition_t *, nullptr,
   1, ARG_TYPES(rmw_context_t *))
@@ -380,9 +395,9 @@ RMW_INTERFACE_FN(rmw_destroy_wait_set,
 
 RMW_INTERFACE_FN(rmw_wait,
   rmw_ret_t, RMW_RET_ERROR,
-  6, ARG_TYPES(
-    rmw_subscriptions_t *, rmw_guard_conditions_t *, rmw_services_t *,
-    rmw_clients_t *, rmw_wait_set_t *, const rmw_time_t *))
+  7, ARG_TYPES(
+    rmw_subscriptions_t *, rmw_guard_conditions_t *, rmw_services_t *, rmw_clients_t *,
+    rmw_events_t *, rmw_wait_set_t *, const rmw_time_t *))
 
 RMW_INTERFACE_FN(rmw_get_publisher_names_and_types_by_node,
   rmw_ret_t, RMW_RET_ERROR,
@@ -457,13 +472,15 @@ void prefetch_symbols(void)
   GET_SYMBOL(rmw_get_serialization_format)
   GET_SYMBOL(rmw_create_node)
   GET_SYMBOL(rmw_destroy_node)
+  GET_SYMBOL(rmw_node_assert_liveliness)
   GET_SYMBOL(rmw_node_get_graph_guard_condition)
   GET_SYMBOL(rmw_create_publisher)
   GET_SYMBOL(rmw_destroy_publisher)
   GET_SYMBOL(rmw_publish)
-  GET_SYMBOL(rmw_publisher_count_matched_subscriptions);
+  GET_SYMBOL(rmw_publisher_count_matched_subscriptions)
   GET_SYMBOL(rmw_publisher_get_actual_qos);
   GET_SYMBOL(rmw_publish_serialized_message)
+  GET_SYMBOL(rmw_publisher_assert_liveliness)
   GET_SYMBOL(rmw_serialize)
   GET_SYMBOL(rmw_deserialize)
   GET_SYMBOL(rmw_create_subscription)
@@ -481,6 +498,7 @@ void prefetch_symbols(void)
   GET_SYMBOL(rmw_destroy_service)
   GET_SYMBOL(rmw_take_request)
   GET_SYMBOL(rmw_send_response)
+  GET_SYMBOL(rmw_take_event)
   GET_SYMBOL(rmw_create_guard_condition)
   GET_SYMBOL(rmw_destroy_guard_condition)
   GET_SYMBOL(rmw_trigger_guard_condition)


### PR DESCRIPTION
This change is to allow events that occur in the rmw layer related to missed deadlines and liveliness policies to be surfaced up to a user. It adds a new parameter to some existing functions and also adds several new functions in support of the liveliness QoS setting and taking events in general. 

Connects to ros2/rmw#171
Related to https://github.com/ros2/design/pull/212