### PR TITLE
Added functions to get qos policies for publishers and subscribers to a topic

### DIFF
--- a/rmw_implementation/src/functions.cpp
+++ b/rmw_implementation/src/functions.cpp
@@ -535,7 +535,7 @@ RMW_INTERFACE_FN(rmw_set_log_severity,
   1, ARG_TYPES(rmw_log_severity_t))
 
 RMW_INTERFACE_FN(rmw_get_publishers_info_by_topic,
-  rmw_ret_t, RMW_RET_UNSUPPORTED,
+  rmw_ret_t, RMW_RET_ERROR,
   5, ARG_TYPES(
     const rmw_node_t *,
     rcutils_allocator_t *,
@@ -544,7 +544,7 @@ RMW_INTERFACE_FN(rmw_get_publishers_info_by_topic,
     rmw_topic_info_array_t *))
 
 RMW_INTERFACE_FN(rmw_get_subscriptions_info_by_topic,
-  rmw_ret_t, RMW_RET_UNSUPPORTED,
+  rmw_ret_t, RMW_RET_ERROR,
   5, ARG_TYPES(
     const rmw_node_t *,
     rcutils_allocator_t *,
@@ -626,9 +626,7 @@ void prefetch_symbols(void)
   GET_SYMBOL(rmw_service_server_is_available)
   GET_SYMBOL(rmw_set_log_severity)
   GET_SYMBOL(rmw_get_publishers_info_by_topic)
-  rmw_reset_error();
   GET_SYMBOL(rmw_get_subscriptions_info_by_topic)
-  rmw_reset_error();
 }
 
 void * symbol_rmw_init = nullptr;

--- a/rmw_implementation/src/functions.cpp
+++ b/rmw_implementation/src/functions.cpp
@@ -33,7 +33,7 @@
 #include "rmw/names_and_types.h"
 #include "rmw/get_node_info_and_types.h"
 #include "rmw/get_service_names_and_types.h"
-#include "rmw/get_topic_info.h"
+#include "rmw/get_topic_endpoint_info.h"
 #include "rmw/get_topic_names_and_types.h"
 #include "rmw/rmw.h"
 
@@ -542,7 +542,7 @@ RMW_INTERFACE_FN(rmw_get_publishers_info_by_topic,
     rcutils_allocator_t *,
     const char *,
     bool,
-    rmw_topic_info_array_t *))
+    rmw_topic_endpoint_info_array_t *))
 
 RMW_INTERFACE_FN(rmw_get_subscriptions_info_by_topic,
   rmw_ret_t, RMW_RET_ERROR,
@@ -551,7 +551,7 @@ RMW_INTERFACE_FN(rmw_get_subscriptions_info_by_topic,
     rcutils_allocator_t *,
     const char *,
     bool,
-    rmw_topic_info_array_t *))
+    rmw_topic_endpoint_info_array_t *))
 
 #define GET_SYMBOL(x) symbol_ ## x = get_symbol(#x);
 

--- a/rmw_implementation/src/functions.cpp
+++ b/rmw_implementation/src/functions.cpp
@@ -534,6 +534,24 @@ RMW_INTERFACE_FN(rmw_set_log_severity,
   rmw_ret_t, RMW_RET_ERROR,
   1, ARG_TYPES(rmw_log_severity_t))
 
+RMW_INTERFACE_FN(rmw_get_publishers_info_by_topic,
+  rmw_ret_t, RMW_RET_ERROR,
+  5, ARG_TYPES(
+    const rmw_node_t *,
+    rcutils_allocator_t *,
+    const char *,
+    bool,
+    rmw_topic_info_array_t *))
+
+RMW_INTERFACE_FN(rmw_get_subscriptions_info_by_topic,
+  rmw_ret_t, RMW_RET_ERROR,
+  5, ARG_TYPES(
+    const rmw_node_t *,
+    rcutils_allocator_t *,
+    const char *,
+    bool,
+    rmw_topic_info_array_t *))
+
 #define GET_SYMBOL(x) symbol_ ## x = get_symbol(#x);
 
 void prefetch_symbols(void)
@@ -607,6 +625,8 @@ void prefetch_symbols(void)
   GET_SYMBOL(rmw_compare_gids_equal)
   GET_SYMBOL(rmw_service_server_is_available)
   GET_SYMBOL(rmw_set_log_severity)
+  GET_SYMBOL(rmw_get_publishers_info_by_topic)
+  GET_SYMBOL(rmw_get_subscriptions_info_by_topic)
 }
 
 void * symbol_rmw_init = nullptr;

--- a/rmw_implementation/src/functions.cpp
+++ b/rmw_implementation/src/functions.cpp
@@ -33,6 +33,7 @@
 #include "rmw/names_and_types.h"
 #include "rmw/get_node_info_and_types.h"
 #include "rmw/get_service_names_and_types.h"
+#include "rmw/get_topic_info.h"
 #include "rmw/get_topic_names_and_types.h"
 #include "rmw/rmw.h"
 

--- a/rmw_implementation/src/functions.cpp
+++ b/rmw_implementation/src/functions.cpp
@@ -535,7 +535,7 @@ RMW_INTERFACE_FN(rmw_set_log_severity,
   1, ARG_TYPES(rmw_log_severity_t))
 
 RMW_INTERFACE_FN(rmw_get_publishers_info_by_topic,
-  rmw_ret_t, RMW_RET_ERROR,
+  rmw_ret_t, RMW_RET_UNSUPPORTED,
   5, ARG_TYPES(
     const rmw_node_t *,
     rcutils_allocator_t *,
@@ -544,7 +544,7 @@ RMW_INTERFACE_FN(rmw_get_publishers_info_by_topic,
     rmw_topic_info_array_t *))
 
 RMW_INTERFACE_FN(rmw_get_subscriptions_info_by_topic,
-  rmw_ret_t, RMW_RET_ERROR,
+  rmw_ret_t, RMW_RET_UNSUPPORTED,
   5, ARG_TYPES(
     const rmw_node_t *,
     rcutils_allocator_t *,
@@ -626,7 +626,9 @@ void prefetch_symbols(void)
   GET_SYMBOL(rmw_service_server_is_available)
   GET_SYMBOL(rmw_set_log_severity)
   GET_SYMBOL(rmw_get_publishers_info_by_topic)
+  rmw_reset_error();
   GET_SYMBOL(rmw_get_subscriptions_info_by_topic)
+  rmw_reset_error();
 }
 
 void * symbol_rmw_init = nullptr;


### PR DESCRIPTION
As a part of implementing [this](https://github.com/ros2/rmw/issues/151) feature. The RMW layer needs to expose apis to retrieve a list of publishers and subscribers along with their QoS policies for a given topic.

- rmw_get_qos_for_subscribers to get the qos policies for subscribers to
a topic
- rmw_get_qos_for_publishers to a get the qos policies for publishers to
a topic

Merge this PR after [this](https://github.com/ros2/rmw/pull/186) is approved as the new functions depend on the newly created structure `rmw_participants_t`