### PR TITLE
Add Python API for RMW implementation lookups

### DIFF
--- a/rmw_implementation/CMakeLists.txt
+++ b/rmw_implementation/CMakeLists.txt
@@ -12,6 +12,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
 
 find_package(rcutils REQUIRED)
 
@@ -19,6 +20,8 @@ find_package(rcutils REQUIRED)
 find_package(poco_vendor)
 find_package(Poco COMPONENTS Foundation)
 find_package(rmw_implementation_cmake REQUIRED)
+
+ament_python_install_package(${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/rmw_implementation/package.xml
+++ b/rmw_implementation/package.xml
@@ -8,6 +8,7 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <build_depend>rcutils</build_depend>
   <build_depend>rmw</build_depend>
@@ -23,6 +24,8 @@
   <depend>libpoco-dev</depend>
   <depend>poco_vendor</depend>
   <depend>rmw_implementation_cmake</depend>
+
+  <exec_depend>ament_index_python</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rmw_implementation/rmw_implementation/__init__.py
+++ b/rmw_implementation/rmw_implementation/__init__.py
@@ -18,9 +18,9 @@ import ament_index_python
 
 
 def get_available_rmw_implementations():
-    """Return a list of all available RMW implementations as registered in the ament index."""
+    """Return the set of all available RMW implementations as registered in the ament index."""
     rmw_implementations = ament_index_python.get_resources('rmw_typesupport')
-    return [name for name in rmw_implementations if name != 'rmw_implementation']
+    return {name for name in rmw_implementations if name != 'rmw_implementation'}
 
 
 __all__ = [

--- a/rmw_implementation/rmw_implementation/__init__.py
+++ b/rmw_implementation/rmw_implementation/__init__.py
@@ -20,7 +20,7 @@ import ament_index_python
 def get_available_rmw_implementations():
     """Return a list of all available RMW implementations as registered in the ament index."""
     rmw_implementations = ament_index_python.get_resources('rmw_typesupport')
-    return [name for name, _ in rmw_implementations if name != 'rmw_implementation']
+    return [name for name in rmw_implementations if name != 'rmw_implementation']
 
 
 __all__ = [

--- a/rmw_implementation/rmw_implementation/__init__.py
+++ b/rmw_implementation/rmw_implementation/__init__.py
@@ -1,0 +1,28 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities to discover available RMW implementations."""
+
+import ament_index_python
+
+
+def get_available_rmw_implementations():
+    """Return a list of all available RMW implementations as registered in the ament index."""
+    rmw_implementations = ament_index_python.get_resources('rmw_typesupport')
+    return [name for name, _ in rmw_implementations if name != 'rmw_implementation']
+
+
+__all__ = [
+    'get_available_rmw_implementations',
+]


### PR DESCRIPTION
This pull request adds a basic Python API to lookup available RMW implementations in the system. Useful when parameterizing `pytests` by RMW implementation in pure Python packages i.e. no CMake templates available. 

Opening PR as a draft for preliminary discussion on whether this functionality should live here or in a separate package of its own.