### PR TITLE
Remove OpenSplice dependency

### DIFF
--- a/rmw_implementation/package.xml
+++ b/rmw_implementation/package.xml
@@ -20,7 +20,6 @@
   <build_depend>rmw_connext_cpp</build_depend>
   <build_depend>rmw_cyclonedds_cpp</build_depend>
   <build_depend>rmw_fastrtps_cpp</build_depend>
-  <build_depend>rmw_opensplice_cpp</build_depend>
   <!-- end of group dependencies added for bloom -->
 
   <depend>libpoco-dev</depend>


### PR DESCRIPTION
Support discontinued from ROS Foxy onwards.
Find a discussion here: https://discourse.ros.org/t/opensplice-move-to-eclipse-cyclone-dds-in-ros-2/12370