### PR TITLE
Added conditional inclusion of Threads

### DIFF
--- a/rmw_implementation/rmw_implementation-extras.cmake.in
+++ b/rmw_implementation/rmw_implementation-extras.cmake.in
@@ -64,5 +64,8 @@ else()
   # since this code is already part of a find_package call of that package
 endif()
 
-find_package(Threads REQUIRED)
+if(BUILD_TESTING)
+  find_package(Threads REQUIRED)
+endif()
+
 list(APPEND rmw_implementation_LIBRARIES "${CMAKE_THREAD_LIBS_INIT}")


### PR DESCRIPTION
We are working on micro-ROS crosscompilation and under certain embedded environments, Threads package is not available.

It seems that Threads is not used along rwm_implementation, so it is proposed to conditionally include it when `BUILD_TESTING` is enabled.