### PR TITLE
Added conditional inclusion of Threads

### DIFF
--- a/rmw_implementation/rmw_implementation-extras.cmake.in
+++ b/rmw_implementation/rmw_implementation-extras.cmake.in
@@ -64,5 +64,6 @@ else()
   # since this code is already part of a find_package call of that package
 endif()
 
-find_package(Threads REQUIRED)
+find_package(Threads)
+
 list(APPEND rmw_implementation_LIBRARIES "${CMAKE_THREAD_LIBS_INIT}")

--- a/rmw_implementation/rmw_implementation-extras.cmake.in
+++ b/rmw_implementation/rmw_implementation-extras.cmake.in
@@ -64,6 +64,12 @@ else()
   # since this code is already part of a find_package call of that package
 endif()
 
-find_package(Threads)
+if(CMAKE_CROSSCOMPILING)
+  find_package(Threads QUIET)
+else()
+  find_package(Threads REQUIRED)
+endif()
 
-list(APPEND rmw_implementation_LIBRARIES "${CMAKE_THREAD_LIBS_INIT}")
+if(Threads_FOUND)
+  list(APPEND rmw_implementation_LIBRARIES "${CMAKE_THREAD_LIBS_INIT}")
+endif()


### PR DESCRIPTION
We are working on micro-ROS crosscompilation and under certain embedded environments, Threads package is not available.

It seems that Threads is not used along rwm_implementation, so it is proposed to conditionally include it when `BUILD_TESTING` is enabled.