### PR TITLE
Removed poco dependency

### DIFF
--- a/rmw_implementation/CMakeLists.txt
+++ b/rmw_implementation/CMakeLists.txt
@@ -46,9 +46,6 @@ if(RMW_IMPLEMENTATION_DISABLE_RUNTIME_SELECTION)
 else()
   message(STATUS "Runtime selection of RMW enabled")
 
-  # provides FindPoco.cmake and Poco on platforms without it
-  find_package(poco_vendor REQUIRED)
-  find_package(Poco REQUIRED COMPONENTS Foundation)
   find_package(rcpputils REQUIRED)
   find_package(rcutils REQUIRED)
   find_package(rmw REQUIRED)
@@ -56,7 +53,6 @@ else()
   add_library(${PROJECT_NAME} SHARED
     src/functions.cpp)
   ament_target_dependencies(${PROJECT_NAME}
-    "Poco"
     "rcpputils"
     "rcutils"
     "rmw")

--- a/rmw_implementation/package.xml
+++ b/rmw_implementation/package.xml
@@ -24,9 +24,6 @@
   <build_depend>rmw_implementation_cmake</build_depend>
   <!-- end of group dependencies added for bloom -->
 
-  <depend>libpoco-dev</depend>
-  <depend>poco_vendor</depend>
-
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/rmw_implementation/src/functions.cpp
+++ b/rmw_implementation/src/functions.cpp
@@ -69,7 +69,7 @@ get_library()
       lib = std::make_shared<rcpputils::SharedLibrary>(library_path.c_str());
     } catch (const std::runtime_error & e) {
       RMW_SET_ERROR_MSG(
-        ("failed to load shared library of rmw implementation." + library_path +
+        ("failed to load shared library of rmw implementation: " + library_path +
         " Exception: " + std::string(e.what())).c_str());
       return nullptr;
     } catch (const std::bad_alloc & e) {

--- a/rmw_implementation/src/functions.cpp
+++ b/rmw_implementation/src/functions.cpp
@@ -88,6 +88,7 @@ get_symbol(const char * symbol_name)
   std::shared_ptr<rcpputils::SharedLibrary> lib = get_library();
 
   if (!lib) {
+    // error message set by get_library()
     return nullptr;
   }
 

--- a/rmw_implementation/src/functions.cpp
+++ b/rmw_implementation/src/functions.cpp
@@ -69,8 +69,8 @@ get_library()
       lib = std::make_shared<rcpputils::SharedLibrary>(library_path.c_str());
     } catch (const std::runtime_error & e) {
       RMW_SET_ERROR_MSG(
-        ("failed to allocate memory " + library_path + ": " + std::string(
-          e.what())).c_str());
+        ("failed to load shared library of rmw implementation." + library_path +
+        " Exception: " + std::string(e.what())).c_str());
       return nullptr;
     } catch (const std::bad_alloc & e) {
       RMW_SET_ERROR_MSG(

--- a/rmw_implementation/src/functions.cpp
+++ b/rmw_implementation/src/functions.cpp
@@ -90,7 +90,8 @@ get_symbol(const char * symbol_name)
     rcutils_allocator_t allocator = rcutils_get_default_allocator();
     char * msg = rcutils_format_string(
       allocator,
-      "failed to resolve symbol '%s' in shared library", symbol_name);
+      "failed to resolve symbol '%s' in shared library '%s'", symbol_name,
+      lib->get_library_path().c_str());
     if (msg) {
       RMW_SET_ERROR_MSG(msg);
       allocator.deallocate(msg, allocator.state);

--- a/rmw_implementation/src/functions.cpp
+++ b/rmw_implementation/src/functions.cpp
@@ -74,8 +74,8 @@ get_library()
       return nullptr;
     } catch (const std::bad_alloc & e) {
       RMW_SET_ERROR_MSG(
-        ("Cannot open library " + library_path + ": " + std::string(
-          e.what())).c_str());
+        ("failed to load shared library of rmw implementation " + library_path + ": " +
+        std::string(e.what())).c_str());
       return nullptr;
     }
   }

--- a/rmw_implementation/src/functions.cpp
+++ b/rmw_implementation/src/functions.cpp
@@ -69,6 +69,11 @@ get_library()
       lib = std::make_shared<rcpputils::SharedLibrary>(library_path.c_str());
     } catch (const std::runtime_error & e) {
       RMW_SET_ERROR_MSG(
+        ("failed to allocate memory " + library_path + ": " + std::string(
+          e.what())).c_str());
+      return nullptr;
+    } catch (const std::bad_alloc & e) {
+      RMW_SET_ERROR_MSG(
         ("Cannot open library " + library_path + ": " + std::string(
           e.what())).c_str());
       return nullptr;


### PR DESCRIPTION
As part of the effort to remove Poco dependency described in this issue https://github.com/ros2/ros2/issues/867 this PR makes use of the recent changes in rcutils https://github.com/ros2/rcutils/pull/215 to load, unload and get symbols from shared libraries instead of using Poco.

Signed-off-by: ahcorde <ahcorde@gmail.com>