### PR TITLE
Complete init/shutdown API test coverage.

### DIFF
--- a/test_rmw_implementation/test/test_init_shutdown.cpp
+++ b/test_rmw_implementation/test/test_init_shutdown.cpp
@@ -28,20 +28,94 @@
 # define CLASSNAME(NAME, SUFFIX) NAME
 #endif
 
-class CLASSNAME (TestInitShutdown, RMW_IMPLEMENTATION) : public ::testing::Test {};
+class CLASSNAME (TestInitShutdown, RMW_IMPLEMENTATION) : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    options = rmw_get_zero_initialized_init_options();
+    rmw_ret_t ret = rmw_init_options_init(&options, rcutils_get_default_allocator());
+    ASSERT_EQ(RMW_RET_OK, ret) << rcutils_get_error_string().str;
+  }
 
-TEST_F(CLASSNAME(TestInitShutdown, RMW_IMPLEMENTATION), init_shutdown) {
-  rmw_context_t context = rmw_get_zero_initialized_context();
-  rmw_init_options_t options = rmw_get_zero_initialized_init_options();
-  rmw_ret_t ret = rmw_init_options_init(&options, rcutils_get_default_allocator());
-  ASSERT_EQ(RMW_RET_OK, ret) << rcutils_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  void TearDown() override
   {
     rmw_ret_t ret = rmw_init_options_fini(&options);
     EXPECT_EQ(RMW_RET_OK, ret) << rcutils_get_error_string().str;
+  }
+
+  rmw_init_options_t options;
+};
+
+TEST_F(CLASSNAME(TestInitShutdown, RMW_IMPLEMENTATION), init_with_bad_arguments) {
+  rmw_context_t context = rmw_get_zero_initialized_context();
+  EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, rmw_init(nullptr, &context));
+  rcutils_reset_error();
+
+  context = rmw_get_zero_initialized_context();
+  EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, rmw_init(&options, nullptr));
+  rcutils_reset_error();
+
+  const char * implementation_identifier = options.implementation_identifier;
+  options.implementation_identifier = "not-a-real-rmw-implementation-identifier";
+  EXPECT_EQ(RMW_RET_INCORRECT_RMW_IMPLEMENTATION, rmw_init(&options, &context));
+  options.implementation_identifier = implementation_identifier;
+  rcutils_reset_error();
+}
+
+TEST_F(CLASSNAME(TestInitShutdown, RMW_IMPLEMENTATION), shutdown_with_bad_arguments) {
+  EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, rmw_shutdown(nullptr));
+  rcutils_reset_error();
+
+  rmw_context_t context = rmw_get_zero_initialized_context();
+  EXPECT_NE(RMW_RET_OK, rmw_shutdown(&context));
+  rcutils_reset_error();
+
+  rmw_ret_t ret = rmw_init(&options, &context);
+  ASSERT_EQ(RMW_RET_OK, ret) << rcutils_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    rmw_ret_t ret = rmw_shutdown(&context);
+    EXPECT_EQ(RMW_RET_OK, ret) << rcutils_get_error_string().str;
+    ret = rmw_context_fini(&context);
+    EXPECT_EQ(RMW_RET_OK, ret) << rcutils_get_error_string().str;
   });
 
-  ret = rmw_init(&options, &context);
+  const char * implementation_identifier = context.implementation_identifier;
+  context.implementation_identifier = "not-a-real-rmw-implementation-identifier";
+  EXPECT_EQ(RMW_RET_INCORRECT_RMW_IMPLEMENTATION, rmw_shutdown(&context));
+  context.implementation_identifier = implementation_identifier;
+  rcutils_reset_error();
+}
+
+TEST_F(CLASSNAME(TestInitShutdown, RMW_IMPLEMENTATION), context_fini_with_bad_arguments) {
+  EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, rmw_context_fini(nullptr));
+  rcutils_reset_error();
+
+  rmw_context_t context = rmw_get_zero_initialized_context();
+  rmw_ret_t ret = rmw_init(&options, &context);
+  ASSERT_EQ(RMW_RET_OK, ret) << rcutils_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    rmw_ret_t ret = rmw_shutdown(&context);
+    EXPECT_EQ(RMW_RET_OK, ret) << rcutils_get_error_string().str;
+    ret = rmw_context_fini(&context);
+    EXPECT_EQ(RMW_RET_OK, ret) << rcutils_get_error_string().str;
+  });
+
+  const char * implementation_identifier = context.implementation_identifier;
+  context.implementation_identifier = "not-a-real-rmw-implementation-identifier";
+  EXPECT_EQ(RMW_RET_INCORRECT_RMW_IMPLEMENTATION, rmw_context_fini(&context));
+  context.implementation_identifier = implementation_identifier;
+  rcutils_reset_error();
+
+  EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, rmw_context_fini(&context));
+  rcutils_reset_error();
+}
+
+TEST_F(CLASSNAME(TestInitShutdown, RMW_IMPLEMENTATION), init_shutdown) {
+  rmw_context_t context = rmw_get_zero_initialized_context();
+  rmw_ret_t ret = rmw_init(&options, &context);
   ASSERT_EQ(RMW_RET_OK, ret) << rcutils_get_error_string().str;
   OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
   {

--- a/test_rmw_implementation/test/test_init_shutdown.cpp
+++ b/test_rmw_implementation/test/test_init_shutdown.cpp
@@ -68,10 +68,12 @@ TEST_F(CLASSNAME(TestInitShutdown, RMW_IMPLEMENTATION), shutdown_with_bad_argume
   rcutils_reset_error();
 
   rmw_context_t context = rmw_get_zero_initialized_context();
-  EXPECT_NE(RMW_RET_OK, rmw_shutdown(&context));
+  rmw_ret_t ret = rmw_shutdown(&context);
+  EXPECT_TRUE((RMW_RET_INCORRECT_RMW_IMPLEMENTATION == ret) ||
+              (RMW_RET_INVALID_ARGUMENT == ret));
   rcutils_reset_error();
 
-  rmw_ret_t ret = rmw_init(&options, &context);
+  ret = rmw_init(&options, &context);
   ASSERT_EQ(RMW_RET_OK, ret) << rcutils_get_error_string().str;
   OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
   {

--- a/test_rmw_implementation/test/test_init_shutdown.cpp
+++ b/test_rmw_implementation/test/test_init_shutdown.cpp
@@ -69,8 +69,9 @@ TEST_F(CLASSNAME(TestInitShutdown, RMW_IMPLEMENTATION), shutdown_with_bad_argume
 
   rmw_context_t context = rmw_get_zero_initialized_context();
   rmw_ret_t ret = rmw_shutdown(&context);
-  EXPECT_TRUE((RMW_RET_INCORRECT_RMW_IMPLEMENTATION == ret) ||
-              (RMW_RET_INVALID_ARGUMENT == ret));
+  EXPECT_TRUE(
+    (RMW_RET_INCORRECT_RMW_IMPLEMENTATION == ret) ||
+    (RMW_RET_INVALID_ARGUMENT == ret));
   rcutils_reset_error();
 
   ret = rmw_init(&options, &context);


### PR DESCRIPTION
Precisely what the title says. Follow-up after #106.