### PR TITLE
Add publisher/subscription matched count API test coverage.

### DIFF
--- a/test_rmw_implementation/CMakeLists.txt
+++ b/test_rmw_implementation/CMakeLists.txt
@@ -34,6 +34,7 @@ if(BUILD_TESTING)
     )
     target_compile_definitions(test_init_shutdown${target_suffix}
       PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
+
     ament_target_dependencies(test_init_shutdown${target_suffix}
       osrf_testing_tools_cpp rcutils rmw rmw_implementation
     )
@@ -65,7 +66,7 @@ if(BUILD_TESTING)
     target_compile_definitions(test_publisher${target_suffix}
       PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
     ament_target_dependencies(test_publisher${target_suffix}
-      rcutils rmw rmw_implementation test_msgs
+      osrf_testing_tools_cpp rcutils rmw rmw_implementation test_msgs
     )
 
     ament_add_gtest(test_subscription${target_suffix}
@@ -75,7 +76,7 @@ if(BUILD_TESTING)
     target_compile_definitions(test_subscription${target_suffix}
       PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
     ament_target_dependencies(test_subscription${target_suffix}
-      rcutils rmw rmw_implementation test_msgs
+      osrf_testing_tools_cpp rcutils rmw rmw_implementation test_msgs
     )
 
     ament_add_gtest(test_serialize_deserialize${target_suffix}

--- a/test_rmw_implementation/CMakeLists.txt
+++ b/test_rmw_implementation/CMakeLists.txt
@@ -34,7 +34,6 @@ if(BUILD_TESTING)
     )
     target_compile_definitions(test_init_shutdown${target_suffix}
       PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
-
     ament_target_dependencies(test_init_shutdown${target_suffix}
       osrf_testing_tools_cpp rcutils rmw rmw_implementation
     )

--- a/test_rmw_implementation/test/config.hpp
+++ b/test_rmw_implementation/test/config.hpp
@@ -1,0 +1,35 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CONFIG_HPP_
+#define CONFIG_HPP_
+
+#include <chrono>
+
+namespace
+{
+
+// Quantities below were empirically adjusted to match the runtime
+// behavior of the following implementations:
+// - rmw_fastrtps_cpp
+// - rmw_fastrtps_dynamic_cpp
+// - rmw_connext_cpp
+// - rmw_cyclonedds_cpp
+// within ci.ros2.org instances.
+
+std::chrono::milliseconds rmw_intraprocess_discovery_delay{100};
+
+}  // namespace
+
+#endif  // CONFIG_HPP_

--- a/test_rmw_implementation/test/test_publisher.cpp
+++ b/test_rmw_implementation/test/test_publisher.cpp
@@ -258,9 +258,7 @@ TEST_F(CLASSNAME(TestPublisherUse, RMW_IMPLEMENTATION), get_actual_qos) {
   EXPECT_EQ(qos_profile.durability, actual_qos_profile.durability);
 }
 
-TEST_F(
-  CLASSNAME(TestPublisherUse, RMW_IMPLEMENTATION),
-  count_matched_subscriptions_with_bad_arguments) {
+TEST_F(CLASSNAME(TestPublisherUse, RMW_IMPLEMENTATION), count_matched_subscriptions_with_bad_args) {
   size_t subscription_count = 0u;
   rmw_ret_t ret = rmw_publisher_count_matched_subscriptions(nullptr, &subscription_count);
   EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, ret);

--- a/test_rmw_implementation/test/test_publisher.cpp
+++ b/test_rmw_implementation/test/test_publisher.cpp
@@ -211,8 +211,10 @@ protected:
   void SetUp() override
   {
     Base::SetUp();
+    // Relax QoS policies to force mismatch.
+    qos_profile.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
     rmw_publisher_options_t options = rmw_get_default_publisher_options();
-    pub = rmw_create_publisher(node, ts, topic_name, qos_profile, &options);
+    pub = rmw_create_publisher(node, ts, topic_name, &qos_profile, &options);
     ASSERT_NE(nullptr, pub) << rmw_get_error_string().str;
   }
 
@@ -223,11 +225,11 @@ protected:
     Base::TearDown();
   }
 
-  rmw_publisher_t * pub;
+  rmw_publisher_t * pub{nullptr};
   const char * const topic_name = "/test";
   const rosidl_message_type_support_t * ts{
     ROSIDL_GET_MSG_TYPE_SUPPORT(test_msgs, msg, BasicTypes)};
-  const rmw_qos_profile_t * qos_profile{&rmw_qos_profile_default};
+  rmw_qos_profile_t qos_profile{rmw_qos_profile_default};
 };
 
 TEST_F(CLASSNAME(TestPublisherUse, RMW_IMPLEMENTATION), get_actual_qos_with_bad_arguments) {
@@ -245,8 +247,76 @@ TEST_F(CLASSNAME(TestPublisherUse, RMW_IMPLEMENTATION), get_actual_qos) {
   rmw_qos_profile_t actual_qos_profile = rmw_qos_profile_unknown;
   rmw_ret_t ret = rmw_publisher_get_actual_qos(pub, &actual_qos_profile);
   EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
-  EXPECT_EQ(rmw_qos_profile_default.history, actual_qos_profile.history);
-  EXPECT_EQ(rmw_qos_profile_default.depth, actual_qos_profile.depth);
-  EXPECT_EQ(rmw_qos_profile_default.reliability, actual_qos_profile.reliability);
-  EXPECT_EQ(rmw_qos_profile_default.durability, actual_qos_profile.durability);
+  EXPECT_EQ(qos_profile.history, actual_qos_profile.history);
+  EXPECT_EQ(qos_profile.depth, actual_qos_profile.depth);
+  EXPECT_EQ(qos_profile.reliability, actual_qos_profile.reliability);
+  EXPECT_EQ(qos_profile.durability, actual_qos_profile.durability);
+}
+
+TEST_F(
+  CLASSNAME(TestPublisherUse, RMW_IMPLEMENTATION),
+  count_matched_subscriptions_with_bad_arguments) {
+  size_t subscription_count = 0u;
+  rmw_ret_t ret = rmw_publisher_count_matched_subscriptions(nullptr, &subscription_count);
+  EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, ret);
+  rmw_reset_error();
+
+  ret = rmw_publisher_count_matched_subscriptions(pub, nullptr);
+  EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, ret);
+  rmw_reset_error();
+
+  const char * implementation_identifier = pub->implementation_identifier;
+  pub->implementation_identifier = "not-an-rmw-implementation-identifier";
+  ret = rmw_publisher_count_matched_subscriptions(pub, &subscription_count);
+  pub->implementation_identifier = implementation_identifier;
+  EXPECT_EQ(RMW_RET_INCORRECT_RMW_IMPLEMENTATION, ret);
+  rmw_reset_error();
+}
+
+TEST_F(CLASSNAME(TestPublisherUse, RMW_IMPLEMENTATION), count_matched_subscriptions) {
+  size_t subscription_count = 0u;
+  rmw_ret_t ret = rmw_publisher_count_matched_subscriptions(pub, &subscription_count);
+  EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+  EXPECT_EQ(0u, subscription_count);
+
+  rmw_subscription_options_t options = rmw_get_default_subscription_options();
+  rmw_subscription_t * sub = rmw_create_subscription(node, ts, topic_name, &qos_profile, &options);
+  ASSERT_NE(nullptr, sub) << rmw_get_error_string().str;
+
+  ret = rmw_publisher_count_matched_subscriptions(pub, &subscription_count);
+  EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+  EXPECT_EQ(1u, subscription_count);
+
+  ret = rmw_destroy_subscription(node, sub);
+  EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+
+  ret = rmw_publisher_count_matched_subscriptions(pub, &subscription_count);
+  EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+  EXPECT_EQ(0u, subscription_count);
+}
+
+TEST_F(CLASSNAME(TestPublisherUse, RMW_IMPLEMENTATION), count_mismatched_subscriptions) {
+  size_t subscription_count = 0u;
+  rmw_ret_t ret = rmw_publisher_count_matched_subscriptions(pub, &subscription_count);
+  EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+  EXPECT_EQ(0u, subscription_count);
+
+  // Tighten QoS policies to force mismatch.
+  rmw_qos_profile_t other_qos_profile = qos_profile;
+  other_qos_profile.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  rmw_subscription_options_t options = rmw_get_default_subscription_options();
+  rmw_subscription_t * sub =
+    rmw_create_subscription(node, ts, topic_name, &other_qos_profile, &options);
+  ASSERT_NE(nullptr, sub) << rmw_get_error_string().str;
+
+  ret = rmw_publisher_count_matched_subscriptions(pub, &subscription_count);
+  EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+  EXPECT_EQ(0u, subscription_count);
+
+  ret = rmw_destroy_subscription(node, sub);
+  EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+
+  ret = rmw_publisher_count_matched_subscriptions(pub, &subscription_count);
+  EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+  EXPECT_EQ(0u, subscription_count);
 }

--- a/test_rmw_implementation/test/test_subscription.cpp
+++ b/test_rmw_implementation/test/test_subscription.cpp
@@ -210,8 +210,10 @@ protected:
   void SetUp() override
   {
     Base::SetUp();
+    // Tighten QoS policies to force mismatch.
+    qos_profile.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
     rmw_subscription_options_t options = rmw_get_default_subscription_options();
-    sub = rmw_create_subscription(node, ts, topic_name, qos_profile, &options);
+    sub = rmw_create_subscription(node, ts, topic_name, &qos_profile, &options);
     ASSERT_NE(nullptr, sub) << rmw_get_error_string().str;
   }
 
@@ -226,7 +228,7 @@ protected:
   const char * const topic_name = "/test";
   const rosidl_message_type_support_t * ts{
     ROSIDL_GET_MSG_TYPE_SUPPORT(test_msgs, msg, BasicTypes)};
-  const rmw_qos_profile_t * qos_profile{&rmw_qos_profile_default};
+  rmw_qos_profile_t qos_profile{rmw_qos_profile_default};
 };
 
 TEST_F(CLASSNAME(TestSubscriptionUse, RMW_IMPLEMENTATION), get_actual_qos_with_bad_arguments) {
@@ -251,8 +253,76 @@ TEST_F(CLASSNAME(TestSubscriptionUse, RMW_IMPLEMENTATION), get_actual_qos) {
   rmw_qos_profile_t actual_qos_profile = rmw_qos_profile_unknown;
   rmw_ret_t ret = rmw_subscription_get_actual_qos(sub, &actual_qos_profile);
   EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
-  EXPECT_EQ(rmw_qos_profile_default.history, actual_qos_profile.history);
-  EXPECT_EQ(rmw_qos_profile_default.depth, actual_qos_profile.depth);
-  EXPECT_EQ(rmw_qos_profile_default.reliability, actual_qos_profile.reliability);
-  EXPECT_EQ(rmw_qos_profile_default.durability, actual_qos_profile.durability);
+  EXPECT_EQ(qos_profile.history, actual_qos_profile.history);
+  EXPECT_EQ(qos_profile.depth, actual_qos_profile.depth);
+  EXPECT_EQ(qos_profile.reliability, actual_qos_profile.reliability);
+  EXPECT_EQ(qos_profile.durability, actual_qos_profile.durability);
+}
+
+TEST_F(
+  CLASSNAME(TestSubscriptionUse, RMW_IMPLEMENTATION),
+  count_matched_publishers_with_bad_arguments) {
+  size_t publisher_count = 0u;
+  rmw_ret_t ret = rmw_subscription_count_matched_publishers(nullptr, &publisher_count);
+  EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, ret);
+  rmw_reset_error();
+
+  ret = rmw_subscription_count_matched_publishers(sub, nullptr);
+  EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, ret);
+  rmw_reset_error();
+
+  const char * implementation_identifier = sub->implementation_identifier;
+  sub->implementation_identifier = "not-an-rmw-implementation-identifier";
+  ret = rmw_subscription_count_matched_publishers(sub, &publisher_count);
+  sub->implementation_identifier = implementation_identifier;
+  EXPECT_EQ(RMW_RET_INCORRECT_RMW_IMPLEMENTATION, ret);
+  rmw_reset_error();
+}
+
+TEST_F(CLASSNAME(TestSubscriptionUse, RMW_IMPLEMENTATION), count_matched_subscriptions) {
+  size_t publisher_count = 0u;
+  rmw_ret_t ret = rmw_subscription_count_matched_publishers(sub, &publisher_count);
+  EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+  EXPECT_EQ(0u, publisher_count);
+
+  rmw_publisher_options_t options = rmw_get_default_publisher_options();
+  rmw_publisher_t * pub = rmw_create_publisher(node, ts, topic_name, &qos_profile, &options);
+  ASSERT_NE(nullptr, sub) << rmw_get_error_string().str;
+
+  ret = rmw_subscription_count_matched_publishers(sub, &publisher_count);
+  EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+  EXPECT_EQ(1u, publisher_count);
+
+  ret = rmw_destroy_publisher(node, pub);
+  EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+
+  ret = rmw_subscription_count_matched_publishers(sub, &publisher_count);
+  EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+  EXPECT_EQ(0u, publisher_count);
+}
+
+TEST_F(CLASSNAME(TestSubscriptionUse, RMW_IMPLEMENTATION), count_mismatched_subscriptions) {
+  size_t publisher_count = 0u;
+  rmw_ret_t ret = rmw_subscription_count_matched_publishers(sub, &publisher_count);
+  EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+  EXPECT_EQ(0u, publisher_count);
+
+  // Relax QoS policies to force mismatch.
+  rmw_qos_profile_t other_qos_profile = qos_profile;
+  other_qos_profile.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+  rmw_publisher_options_t options = rmw_get_default_publisher_options();
+  rmw_publisher_t * pub =
+    rmw_create_publisher(node, ts, topic_name, &other_qos_profile, &options);
+  ASSERT_NE(nullptr, pub) << rmw_get_error_string().str;
+
+  ret = rmw_subscription_count_matched_publishers(sub, &publisher_count);
+  EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+  EXPECT_EQ(0u, publisher_count);
+
+  ret = rmw_destroy_publisher(node, pub);
+  EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+
+  ret = rmw_subscription_count_matched_publishers(sub, &publisher_count);
+  EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+  EXPECT_EQ(0u, publisher_count);
 }

--- a/test_rmw_implementation/test/test_subscription.cpp
+++ b/test_rmw_implementation/test/test_subscription.cpp
@@ -264,9 +264,7 @@ TEST_F(CLASSNAME(TestSubscriptionUse, RMW_IMPLEMENTATION), get_actual_qos) {
   EXPECT_EQ(qos_profile.durability, actual_qos_profile.durability);
 }
 
-TEST_F(
-  CLASSNAME(TestSubscriptionUse, RMW_IMPLEMENTATION),
-  count_matched_publishers_with_bad_arguments) {
+TEST_F(CLASSNAME(TestSubscriptionUse, RMW_IMPLEMENTATION), count_matched_publishers_with_bad_args) {
   size_t publisher_count = 0u;
   rmw_ret_t ret = rmw_subscription_count_matched_publishers(nullptr, &publisher_count);
   EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, ret);

--- a/test_rmw_implementation/test/test_subscription.cpp
+++ b/test_rmw_implementation/test/test_subscription.cpp
@@ -14,6 +14,8 @@
 
 #include <gtest/gtest.h>
 
+#include "osrf_testing_tools_cpp/memory_tools/gtest_quickstart.hpp"
+
 #include "rcutils/allocator.h"
 #include "rcutils/strdup.h"
 
@@ -21,6 +23,9 @@
 #include "rmw/error_handling.h"
 
 #include "test_msgs/msg/basic_types.h"
+
+#include "./config.hpp"
+#include "./testing_macros.hpp"
 
 #ifdef RMW_IMPLEMENTATION
 # define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
@@ -280,8 +285,14 @@ TEST_F(
 }
 
 TEST_F(CLASSNAME(TestSubscriptionUse, RMW_IMPLEMENTATION), count_matched_subscriptions) {
+  osrf_testing_tools_cpp::memory_tools::ScopedQuickstartGtest sqg;
+
+  rmw_ret_t ret;
   size_t publisher_count = 0u;
-  rmw_ret_t ret = rmw_subscription_count_matched_publishers(sub, &publisher_count);
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
+    ret = rmw_subscription_count_matched_publishers(sub, &publisher_count);
+  });
   EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
   EXPECT_EQ(0u, publisher_count);
 
@@ -289,21 +300,49 @@ TEST_F(CLASSNAME(TestSubscriptionUse, RMW_IMPLEMENTATION), count_matched_subscri
   rmw_publisher_t * pub = rmw_create_publisher(node, ts, topic_name, &qos_profile, &options);
   ASSERT_NE(nullptr, sub) << rmw_get_error_string().str;
 
-  ret = rmw_subscription_count_matched_publishers(sub, &publisher_count);
+  // TODO(hidmic): revisit when https://github.com/ros2/rmw/issues/264 is resolved.
+  SLEEP_AND_RETRY_UNTIL(rmw_intraprocess_discovery_delay, rmw_intraprocess_discovery_delay * 10) {
+    ret = rmw_subscription_count_matched_publishers(sub, &publisher_count);
+    if (RMW_RET_OK == ret && 1u == publisher_count) {
+      break;
+    }
+  }
+
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
+    ret = rmw_subscription_count_matched_publishers(sub, &publisher_count);
+  });
   EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
   EXPECT_EQ(1u, publisher_count);
 
   ret = rmw_destroy_publisher(node, pub);
   EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
 
-  ret = rmw_subscription_count_matched_publishers(sub, &publisher_count);
+  // TODO(hidmic): revisit when https://github.com/ros2/rmw/issues/264 is resolved.
+  SLEEP_AND_RETRY_UNTIL(rmw_intraprocess_discovery_delay, rmw_intraprocess_discovery_delay * 10) {
+    ret = rmw_subscription_count_matched_publishers(sub, &publisher_count);
+    if (RMW_RET_OK == ret && 0u == publisher_count) {
+      break;
+    }
+  }
+
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
+    ret = rmw_subscription_count_matched_publishers(sub, &publisher_count);
+  });
   EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
   EXPECT_EQ(0u, publisher_count);
 }
 
 TEST_F(CLASSNAME(TestSubscriptionUse, RMW_IMPLEMENTATION), count_mismatched_subscriptions) {
+  osrf_testing_tools_cpp::memory_tools::ScopedQuickstartGtest sqg;
+
+  rmw_ret_t ret;
   size_t publisher_count = 0u;
-  rmw_ret_t ret = rmw_subscription_count_matched_publishers(sub, &publisher_count);
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
+    ret = rmw_subscription_count_matched_publishers(sub, &publisher_count);
+  });
   EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
   EXPECT_EQ(0u, publisher_count);
 
@@ -315,14 +354,28 @@ TEST_F(CLASSNAME(TestSubscriptionUse, RMW_IMPLEMENTATION), count_mismatched_subs
     rmw_create_publisher(node, ts, topic_name, &other_qos_profile, &options);
   ASSERT_NE(nullptr, pub) << rmw_get_error_string().str;
 
-  ret = rmw_subscription_count_matched_publishers(sub, &publisher_count);
+  // TODO(hidmic): revisit when https://github.com/ros2/rmw/issues/264 is resolved.
+  SLEEP_AND_RETRY_UNTIL(rmw_intraprocess_discovery_delay, rmw_intraprocess_discovery_delay * 10) {
+    ret = rmw_subscription_count_matched_publishers(sub, &publisher_count);
+    if (RMW_RET_OK == ret && 0u != publisher_count) {  // Early return on failure.
+      break;
+    }
+  }
+
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
+    ret = rmw_subscription_count_matched_publishers(sub, &publisher_count);
+  });
   EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
   EXPECT_EQ(0u, publisher_count);
 
   ret = rmw_destroy_publisher(node, pub);
   EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
 
-  ret = rmw_subscription_count_matched_publishers(sub, &publisher_count);
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
+    ret = rmw_subscription_count_matched_publishers(sub, &publisher_count);
+  });
   EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
   EXPECT_EQ(0u, publisher_count);
 }

--- a/test_rmw_implementation/test/testing_macros.hpp
+++ b/test_rmw_implementation/test/testing_macros.hpp
@@ -23,9 +23,8 @@
  * \note Time is measured against OS provided steady clock.
  */
 #define SLEEP_AND_RETRY_UNTIL(delay, timeout) for ( \
-    auto loop_start_time = std::chrono::steady_clock::now(), \
-    iteration_start_time = loop_start_time; \
+    auto loop_start_time = std::chrono::steady_clock::now(); \
     std::chrono::steady_clock::now() - loop_start_time < timeout; \
-    iteration_start_time += delay, std::this_thread::sleep_until(iteration_start_time))
+    std::this_thread::sleep_for(delay))
 
 #endif  // TESTING_MACROS_HPP_

--- a/test_rmw_implementation/test/testing_macros.hpp
+++ b/test_rmw_implementation/test/testing_macros.hpp
@@ -1,0 +1,31 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TESTING_MACROS_HPP_
+#define TESTING_MACROS_HPP_
+
+#include <chrono>
+#include <thread>
+
+/// Retry until `timeout` expires, sleeping for `delay` in between attempts.
+/*
+ * \note Time is measured against OS provided steady clock.
+ */
+#define SLEEP_AND_RETRY_UNTIL(delay, timeout) for ( \
+    auto loop_start_time = std::chrono::steady_clock::now(), \
+    iteration_start_time = loop_start_time; \
+    std::chrono::steady_clock::now() - loop_start_time < timeout; \
+    iteration_start_time += delay, std::this_thread::sleep_until(iteration_start_time))
+
+#endif  // TESTING_MACROS_HPP_


### PR DESCRIPTION
Connected to https://github.com/ros2/rmw/pull/262. Depends on https://github.com/ros2/rmw_fastrtps/pull/424, https://github.com/ros2/rmw_connext/pull/451, and https://github.com/ros2/rmw_cyclonedds/pull/223.