### PR TITLE
Add rmw_get_serialization_format() smoke test.

### DIFF
--- a/test_rmw_implementation/test/test_serialize_deserialize.cpp
+++ b/test_rmw_implementation/test/test_serialize_deserialize.cpp
@@ -37,6 +37,12 @@ class CLASSNAME (TestSerializeDeserialize, RMW_IMPLEMENTATION) : public ::testin
 {
 };
 
+TEST_F(CLASSNAME(TestSerializeDeserialize, RMW_IMPLEMENTATION), get_serialization_format) {
+  const char * serialization_format = rmw_get_serialization_format();
+  EXPECT_NE(nullptr, serialization_format);
+  EXPECT_STREQ(serialization_format, rmw_get_serialization_format());
+}
+
 TEST_F(CLASSNAME(TestSerializeDeserialize, RMW_IMPLEMENTATION), serialize_with_bad_arguments) {
   const rosidl_message_type_support_t * ts{
     ROSIDL_GET_MSG_TYPE_SUPPORT(test_msgs, msg, BasicTypes)};


### PR DESCRIPTION
Precisely what the title says. 

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=12378)](http://ci.ros2.org/job/ci_linux/12378/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7347)](http://ci.ros2.org/job/ci_linux-aarch64/7347/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10090)](http://ci.ros2.org/job/ci_osx/10090/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12290)](http://ci.ros2.org/job/ci_windows/12290/)
