### PR TITLE
Add missing empty topic name tests.

### DIFF
--- a/test_rmw_implementation/test/test_publisher.cpp
+++ b/test_rmw_implementation/test/test_publisher.cpp
@@ -121,6 +121,10 @@ TEST_F(CLASSNAME(TestPublisher, RMW_IMPLEMENTATION), create_with_bad_arguments) 
   EXPECT_EQ(nullptr, pub);
   rmw_reset_error();
 
+  pub = rmw_create_publisher(node, ts, "", &rmw_qos_profile_default, &options);
+  EXPECT_EQ(nullptr, pub);
+  rmw_reset_error();
+
   constexpr char topic_name_with_spaces[] = "/foo bar";
   pub = rmw_create_publisher(node, ts, topic_name_with_spaces, &rmw_qos_profile_default, &options);
   EXPECT_EQ(nullptr, pub);

--- a/test_rmw_implementation/test/test_subscription.cpp
+++ b/test_rmw_implementation/test/test_subscription.cpp
@@ -119,6 +119,10 @@ TEST_F(CLASSNAME(TestSubscription, RMW_IMPLEMENTATION), create_with_bad_argument
   EXPECT_EQ(nullptr, sub);
   rmw_reset_error();
 
+  sub = rmw_create_subscription(node, ts, "", &rmw_qos_profile_default, &options);
+  EXPECT_EQ(nullptr, sub);
+  rmw_reset_error();
+
   constexpr char topic_name_with_spaces[] = "/foo bar";
   sub =
     rmw_create_subscription(node, ts, topic_name_with_spaces, &rmw_qos_profile_default, &options);


### PR DESCRIPTION
Affecting `rmw_create_publisher()` and `rmw_create_subscription()` tests.

CI up to `test_rmw_implementation`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=12405)](http://ci.ros2.org/job/ci_linux/12405/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7372)](http://ci.ros2.org/job/ci_linux-aarch64/7372/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10115)](http://ci.ros2.org/job/ci_osx/10115/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12318)](http://ci.ros2.org/job/ci_windows/12318/)
