### PR TITLE
Added rmw_publisher_allocation and rmw_subscription_allocation related tests

### DIFF
--- a/test_rmw_implementation/CMakeLists.txt
+++ b/test_rmw_implementation/CMakeLists.txt
@@ -87,6 +87,25 @@ if(BUILD_TESTING)
     ament_target_dependencies(test_serialize_deserialize${target_suffix}
       rcutils rmw rmw_implementation test_msgs
     )
+
+    ament_add_gtest(test_publisher_allocator${target_suffix}
+      test/test_publisher_allocator.cpp
+      ENV ${rmw_implementation_env_var}
+    )
+    target_compile_definitions(test_publisher_allocator${target_suffix}
+      PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
+    ament_target_dependencies(test_publisher_allocator${target_suffix}
+      rmw rmw_implementation
+    )
+    ament_add_gtest(test_subscription_allocator${target_suffix}
+      test/test_subscription_allocator.cpp
+      ENV ${rmw_implementation_env_var}
+    )
+    target_compile_definitions(test_subscription_allocator${target_suffix}
+      PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
+    ament_target_dependencies(test_subscription_allocator${target_suffix}
+      rmw rmw_implementation
+    )
   endmacro()
 
   call_for_each_rmw_implementation(test_api)

--- a/test_rmw_implementation/test/test_publisher_allocator.cpp
+++ b/test_rmw_implementation/test/test_publisher_allocator.cpp
@@ -32,15 +32,3 @@ TEST_F(CLASSNAME(TestInitOptions, RMW_IMPLEMENTATION), init_fini_publisher_alloc
   ret = rmw_fini_publisher_allocation(nullptr);
   EXPECT_EQ(ret, RMW_RET_UNSUPPORTED);
 }
-
-TEST_F(CLASSNAME(TestInitOptions, RMW_IMPLEMENTATION), rmw_publish_loaned_message)
-{
-  rmw_ret_t ret = rmw_publish_loaned_message(nullptr, nullptr, nullptr);
-  EXPECT_EQ(ret, RMW_RET_UNSUPPORTED);
-
-  ret = rmw_borrow_loaned_message(nullptr, nullptr, nullptr);
-  EXPECT_EQ(ret, RMW_RET_UNSUPPORTED);
-
-  ret = rmw_return_loaned_message_from_publisher(nullptr, nullptr);
-  EXPECT_EQ(ret, RMW_RET_UNSUPPORTED);
-}

--- a/test_rmw_implementation/test/test_publisher_allocator.cpp
+++ b/test_rmw_implementation/test/test_publisher_allocator.cpp
@@ -26,8 +26,7 @@ class CLASSNAME (TestPublisherAllocator, RMW_IMPLEMENTATION) : public ::testing:
 
 TEST_F(CLASSNAME(TestPublisherAllocator, RMW_IMPLEMENTATION), init_fini_publisher_allocation)
 {
-  if (rmw_init_publisher_allocation(nullptr, nullptr, nullptr) != RMW_RET_UNSUPPORTED)
-  {
+  if (rmw_init_publisher_allocation(nullptr, nullptr, nullptr) != RMW_RET_UNSUPPORTED) {
     // Add tests here when the implementation it's supported
     GTEST_SKIP();
   } else {

--- a/test_rmw_implementation/test/test_publisher_allocator.cpp
+++ b/test_rmw_implementation/test/test_publisher_allocator.cpp
@@ -22,9 +22,9 @@
 # define CLASSNAME(NAME, SUFFIX) NAME
 #endif
 
-class CLASSNAME (TestInitOptions, RMW_IMPLEMENTATION) : public ::testing::Test {};
+class CLASSNAME (TestPublisherAllocator, RMW_IMPLEMENTATION) : public ::testing::Test {};
 
-TEST_F(CLASSNAME(TestInitOptions, RMW_IMPLEMENTATION), init_fini_publisher_allocation)
+TEST_F(CLASSNAME(TestPublisherAllocator, RMW_IMPLEMENTATION), init_fini_publisher_allocation)
 {
   rmw_ret_t ret = rmw_init_publisher_allocation(nullptr, nullptr, nullptr);
   EXPECT_EQ(ret, RMW_RET_UNSUPPORTED);

--- a/test_rmw_implementation/test/test_publisher_allocator.cpp
+++ b/test_rmw_implementation/test/test_publisher_allocator.cpp
@@ -26,9 +26,12 @@ class CLASSNAME (TestPublisherAllocator, RMW_IMPLEMENTATION) : public ::testing:
 
 TEST_F(CLASSNAME(TestPublisherAllocator, RMW_IMPLEMENTATION), init_fini_publisher_allocation)
 {
-  rmw_ret_t ret = rmw_init_publisher_allocation(nullptr, nullptr, nullptr);
-  EXPECT_EQ(ret, RMW_RET_UNSUPPORTED);
-
-  ret = rmw_fini_publisher_allocation(nullptr);
-  EXPECT_EQ(ret, RMW_RET_UNSUPPORTED);
+  if (rmw_init_publisher_allocation(nullptr, nullptr, nullptr) != RMW_RET_UNSUPPORTED)
+  {
+    // Add tests here when the implementation it's supported
+    GTEST_SKIP();
+  } else {
+    rmw_ret_t ret = rmw_fini_publisher_allocation(nullptr);
+    EXPECT_EQ(ret, RMW_RET_UNSUPPORTED);
+  }
 }

--- a/test_rmw_implementation/test/test_publisher_allocator.cpp
+++ b/test_rmw_implementation/test/test_publisher_allocator.cpp
@@ -1,0 +1,46 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <gtest/gtest.h>
+
+#include "rmw/rmw.h"
+
+#ifdef RMW_IMPLEMENTATION
+# define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
+# define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
+#else
+# define CLASSNAME(NAME, SUFFIX) NAME
+#endif
+
+class CLASSNAME (TestInitOptions, RMW_IMPLEMENTATION) : public ::testing::Test {};
+
+TEST_F(CLASSNAME(TestInitOptions, RMW_IMPLEMENTATION), init_fini_publisher_allocation)
+{
+  rmw_ret_t ret = rmw_init_publisher_allocation(nullptr, nullptr, nullptr);
+  EXPECT_EQ(ret, RMW_RET_UNSUPPORTED);
+
+  ret = rmw_fini_publisher_allocation(nullptr);
+  EXPECT_EQ(ret, RMW_RET_UNSUPPORTED);
+}
+
+TEST_F(CLASSNAME(TestInitOptions, RMW_IMPLEMENTATION), rmw_publish_loaned_message)
+{
+  rmw_ret_t ret = rmw_publish_loaned_message(nullptr, nullptr, nullptr);
+  EXPECT_EQ(ret, RMW_RET_UNSUPPORTED);
+
+  ret = rmw_borrow_loaned_message(nullptr, nullptr, nullptr);
+  EXPECT_EQ(ret, RMW_RET_UNSUPPORTED);
+
+  ret = rmw_return_loaned_message_from_publisher(nullptr, nullptr);
+  EXPECT_EQ(ret, RMW_RET_UNSUPPORTED);
+}

--- a/test_rmw_implementation/test/test_subscription_allocator.cpp
+++ b/test_rmw_implementation/test/test_subscription_allocator.cpp
@@ -22,9 +22,9 @@
 # define CLASSNAME(NAME, SUFFIX) NAME
 #endif
 
-class CLASSNAME (TestInitOptions, RMW_IMPLEMENTATION) : public ::testing::Test {};
+class CLASSNAME (TestSubscriptionAllocator, RMW_IMPLEMENTATION) : public ::testing::Test {};
 
-TEST_F(CLASSNAME(TestInitOptions, RMW_IMPLEMENTATION), init_fini_subscription_allocation)
+TEST_F(CLASSNAME(TestSubscriptionAllocator, RMW_IMPLEMENTATION), init_fini_subscription_allocation)
 {
   rmw_ret_t ret  = rmw_init_subscription_allocation(nullptr, nullptr, nullptr);
   EXPECT_EQ(ret, RMW_RET_UNSUPPORTED);

--- a/test_rmw_implementation/test/test_subscription_allocator.cpp
+++ b/test_rmw_implementation/test/test_subscription_allocator.cpp
@@ -26,8 +26,7 @@ class CLASSNAME (TestSubscriptionAllocator, RMW_IMPLEMENTATION) : public ::testi
 
 TEST_F(CLASSNAME(TestSubscriptionAllocator, RMW_IMPLEMENTATION), init_fini_subscription_allocation)
 {
-  if (rmw_init_subscription_allocation(nullptr, nullptr, nullptr) != RMW_RET_UNSUPPORTED)
-  {
+  if (rmw_init_subscription_allocation(nullptr, nullptr, nullptr) != RMW_RET_UNSUPPORTED) {
     // Add tests here when the implementation it's supported
     GTEST_SKIP();
   } else {

--- a/test_rmw_implementation/test/test_subscription_allocator.cpp
+++ b/test_rmw_implementation/test/test_subscription_allocator.cpp
@@ -1,0 +1,34 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <gtest/gtest.h>
+
+#include "rmw/rmw.h"
+
+#ifdef RMW_IMPLEMENTATION
+# define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
+# define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
+#else
+# define CLASSNAME(NAME, SUFFIX) NAME
+#endif
+
+class CLASSNAME (TestInitOptions, RMW_IMPLEMENTATION) : public ::testing::Test {};
+
+TEST_F(CLASSNAME(TestInitOptions, RMW_IMPLEMENTATION), init_fini_subscription_allocation)
+{
+  rmw_ret_t ret  = rmw_init_subscription_allocation(nullptr, nullptr, nullptr);
+  EXPECT_EQ(ret, RMW_RET_UNSUPPORTED);
+
+  ret  = rmw_fini_subscription_allocation(nullptr);
+  EXPECT_EQ(ret, RMW_RET_UNSUPPORTED);
+}

--- a/test_rmw_implementation/test/test_subscription_allocator.cpp
+++ b/test_rmw_implementation/test/test_subscription_allocator.cpp
@@ -26,9 +26,12 @@ class CLASSNAME (TestSubscriptionAllocator, RMW_IMPLEMENTATION) : public ::testi
 
 TEST_F(CLASSNAME(TestSubscriptionAllocator, RMW_IMPLEMENTATION), init_fini_subscription_allocation)
 {
-  rmw_ret_t ret  = rmw_init_subscription_allocation(nullptr, nullptr, nullptr);
-  EXPECT_EQ(ret, RMW_RET_UNSUPPORTED);
-
-  ret  = rmw_fini_subscription_allocation(nullptr);
-  EXPECT_EQ(ret, RMW_RET_UNSUPPORTED);
+  if (rmw_init_subscription_allocation(nullptr, nullptr, nullptr) != RMW_RET_UNSUPPORTED)
+  {
+    // Add tests here when the implementation it's supported
+    GTEST_SKIP();
+  } else {
+    rmw_ret_t ret = rmw_fini_subscription_allocation(nullptr);
+    EXPECT_EQ(ret, RMW_RET_UNSUPPORTED);
+  }
 }


### PR DESCRIPTION
Added `rmw_publisher_allocation` and `rmw_subscription_allocation` related tests. This functions are unimplemented. Arguments inside the functions are all casted to void to avoid warnings.

Signed-off-by: ahcorde <ahcorde@gmail.com>