### PR TITLE
Added test for rmw_get_serialized_message_size

### DIFF
--- a/test_rmw_implementation/test/test_serialize_deserialize.cpp
+++ b/test_rmw_implementation/test/test_serialize_deserialize.cpp
@@ -122,3 +122,11 @@ TEST_F(CLASSNAME(TestSerializeDeserialize, RMW_IMPLEMENTATION), clean_round_trip
   EXPECT_EQ(RMW_RET_OK, rmw_serialized_message_fini(&serialized_message)) <<
     rmw_get_error_string().str;
 }
+
+TEST_F(CLASSNAME(TestSerializeDeserialize, RMW_IMPLEMENTATION), rmw_get_serialized_message_size)
+{
+  if (rmw_get_serialized_message_size(nullptr, nullptr, nullptr) != RMW_RET_UNSUPPORTED) {
+    // TODO(anyone): Add tests here when the implementation it's supported
+    GTEST_SKIP();
+  }
+}


### PR DESCRIPTION
Related with:
  - https://github.com/ros2/rmw_fastrtps/pull/452
  - https://github.com/ros2/rmw_connext/pull/467
  - https://github.com/ros2/rmw_cyclonedds/pull/250 
  - Updated API: https://github.com/ros2/rmw/pull/281

Signed-off-by: ahcorde <ahcorde@gmail.com>