### PR TITLE
Add nominal test for symbol prefetch() and unload.

### DIFF
--- a/rmw_implementation/test/test_functions.cpp
+++ b/rmw_implementation/test/test_functions.cpp
@@ -55,3 +55,8 @@ TEST(Functions, load_and_lookup_with_internal_errors) {
     }
   });
 }
+
+TEST(Functions, nominal_prefetch_and_unload) {
+  prefetch_symbols();
+  unload_library();
+}


### PR DESCRIPTION
Precisely what the title says. Follow up after #127.

CI up to `rmw_implementation`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=12525)](http://ci.ros2.org/job/ci_linux/12525/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7494)](http://ci.ros2.org/job/ci_linux-aarch64/7494/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10237)](http://ci.ros2.org/job/ci_osx/10237/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12444)](http://ci.ros2.org/job/ci_windows/12444/)
