### PR TITLE
Fix test_wait_set.cpp to not wait on uninitialized arrays.

### DIFF
--- a/test_rmw_implementation/CMakeLists.txt
+++ b/test_rmw_implementation/CMakeLists.txt
@@ -116,7 +116,7 @@ if(BUILD_TESTING)
     target_compile_definitions(test_wait_set${target_suffix}
       PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
     ament_target_dependencies(test_wait_set${target_suffix}
-      rmw rmw_implementation rcutils osrf_testing_tools_cpp
+      rmw rmw_implementation rcutils osrf_testing_tools_cpp test_msgs
     )
 
     ament_add_gtest(test_graph_api${target_suffix}

--- a/test_rmw_implementation/test/test_wait_set.cpp
+++ b/test_rmw_implementation/test/test_wait_set.cpp
@@ -208,6 +208,25 @@ TEST_F(CLASSNAME(TestWaitSetUse, RMW_IMPLEMENTATION), rmw_wait)
   INITIALIZE_ARRAY(clients, client, number_of_clients);
   INITIALIZE_ARRAY(events, event, number_of_events);
 
+  const char * implementation_identifier = wait_set->implementation_identifier;
+  wait_set->implementation_identifier = "not-an-rmw-implementation-identifier";
+  subscriptions.subscribers[0] = sub->data;
+  guard_conditions.guard_conditions[0] = gc->data;
+  services.services[0] = srv->data;
+  clients.clients[0] = client->data;
+  events.events[0] = &event;
+  ret = rmw_wait(
+    &subscriptions, &guard_conditions, &services, &clients, &events, wait_set,
+    &timeout_argument);
+  wait_set->implementation_identifier = implementation_identifier;
+  EXPECT_EQ(ret, RMW_RET_INCORRECT_RMW_IMPLEMENTATION) << rcutils_get_error_string().str;
+  EXPECT_NE(nullptr, subscriptions.subscribers[0]);  // left unchanged
+  EXPECT_NE(nullptr, guard_conditions.guard_conditions[0]);
+  EXPECT_NE(nullptr, services.services[0]);
+  EXPECT_NE(nullptr, clients.clients[0]);
+  EXPECT_NE(nullptr, events.events[0]);
+  rmw_reset_error();
+
   // Used a valid wait_set
   ret = rmw_wait(nullptr, nullptr, nullptr, nullptr, nullptr, wait_set, &timeout_argument);
   EXPECT_EQ(ret, RMW_RET_TIMEOUT) << rcutils_get_error_string().str;
@@ -221,7 +240,7 @@ TEST_F(CLASSNAME(TestWaitSetUse, RMW_IMPLEMENTATION), rmw_wait)
   subscriptions.subscribers[0] = sub->data;
   ret = rmw_wait(&subscriptions, nullptr, nullptr, nullptr, nullptr, wait_set, &timeout_argument);
   EXPECT_EQ(ret, RMW_RET_TIMEOUT) << rcutils_get_error_string().str;
-  EXPECT_NE(nullptr, subscriptions.subscribers[0]);
+  EXPECT_EQ(nullptr, subscriptions.subscribers[0]);
   rmw_reset_error();
 
   // Used a valid wait_set and subscription with no timeout
@@ -230,7 +249,7 @@ TEST_F(CLASSNAME(TestWaitSetUse, RMW_IMPLEMENTATION), rmw_wait)
     &subscriptions, nullptr, nullptr, nullptr, nullptr, wait_set,
     &timeout_argument_zero);
   EXPECT_EQ(ret, RMW_RET_TIMEOUT) << rcutils_get_error_string().str;
-  EXPECT_NE(nullptr, subscriptions.subscribers[0]);
+  EXPECT_EQ(nullptr, subscriptions.subscribers[0]);
   rmw_reset_error();
 
   // Used a valid wait_set, subscription and guard_conditions with 100ms timeout
@@ -240,8 +259,8 @@ TEST_F(CLASSNAME(TestWaitSetUse, RMW_IMPLEMENTATION), rmw_wait)
     &subscriptions, &guard_conditions, nullptr, nullptr, nullptr, wait_set,
     &timeout_argument);
   EXPECT_EQ(ret, RMW_RET_TIMEOUT) << rcutils_get_error_string().str;
-  EXPECT_NE(nullptr, subscriptions.subscribers[0]);
-  EXPECT_NE(nullptr, guard_conditions.guard_conditions[0]);
+  EXPECT_EQ(nullptr, subscriptions.subscribers[0]);
+  EXPECT_EQ(nullptr, guard_conditions.guard_conditions[0]);
   rmw_reset_error();
 
   // Used a valid wait_set, subscription and guard_conditions with no timeout
@@ -251,8 +270,8 @@ TEST_F(CLASSNAME(TestWaitSetUse, RMW_IMPLEMENTATION), rmw_wait)
     &subscriptions, &guard_conditions, nullptr, nullptr, nullptr, wait_set,
     &timeout_argument_zero);
   EXPECT_EQ(ret, RMW_RET_TIMEOUT) << rcutils_get_error_string().str;
-  EXPECT_NE(nullptr, subscriptions.subscribers[0]);
-  EXPECT_NE(nullptr, guard_conditions.guard_conditions[0]);
+  EXPECT_EQ(nullptr, subscriptions.subscribers[0]);
+  EXPECT_EQ(nullptr, guard_conditions.guard_conditions[0]);
   rmw_reset_error();
 
   // Used a valid wait_set, subscription, guard_conditions and services with 100ms timeout
@@ -263,9 +282,9 @@ TEST_F(CLASSNAME(TestWaitSetUse, RMW_IMPLEMENTATION), rmw_wait)
     &subscriptions, &guard_conditions, &services, nullptr, nullptr, wait_set,
     &timeout_argument);
   EXPECT_EQ(ret, RMW_RET_TIMEOUT) << rcutils_get_error_string().str;
-  EXPECT_NE(nullptr, subscriptions.subscribers[0]);
-  EXPECT_NE(nullptr, guard_conditions.guard_conditions[0]);
-  EXPECT_NE(nullptr, services.services[0]);
+  EXPECT_EQ(nullptr, subscriptions.subscribers[0]);
+  EXPECT_EQ(nullptr, guard_conditions.guard_conditions[0]);
+  EXPECT_EQ(nullptr, services.services[0]);
   rmw_reset_error();
 
   // Used a valid wait_set, subscription, guard_conditions and services with no timeout
@@ -276,9 +295,9 @@ TEST_F(CLASSNAME(TestWaitSetUse, RMW_IMPLEMENTATION), rmw_wait)
     &subscriptions, &guard_conditions, &services, nullptr, nullptr, wait_set,
     &timeout_argument_zero);
   EXPECT_EQ(ret, RMW_RET_TIMEOUT) << rcutils_get_error_string().str;
-  EXPECT_NE(nullptr, subscriptions.subscribers[0]);
-  EXPECT_NE(nullptr, guard_conditions.guard_conditions[0]);
-  EXPECT_NE(nullptr, services.services[0]);
+  EXPECT_EQ(nullptr, subscriptions.subscribers[0]);
+  EXPECT_EQ(nullptr, guard_conditions.guard_conditions[0]);
+  EXPECT_EQ(nullptr, services.services[0]);
   rmw_reset_error();
 
   // Used a valid wait_set, subscription, guard_conditions, services and clients with 100ms timeout
@@ -290,10 +309,10 @@ TEST_F(CLASSNAME(TestWaitSetUse, RMW_IMPLEMENTATION), rmw_wait)
     &subscriptions, &guard_conditions, &services, &clients, nullptr, wait_set,
     &timeout_argument);
   EXPECT_EQ(ret, RMW_RET_TIMEOUT) << rcutils_get_error_string().str;
-  EXPECT_NE(nullptr, subscriptions.subscribers[0]);
-  EXPECT_NE(nullptr, guard_conditions.guard_conditions[0]);
-  EXPECT_NE(nullptr, services.services[0]);
-  EXPECT_NE(nullptr, clients.clients[0]);
+  EXPECT_EQ(nullptr, subscriptions.subscribers[0]);
+  EXPECT_EQ(nullptr, guard_conditions.guard_conditions[0]);
+  EXPECT_EQ(nullptr, services.services[0]);
+  EXPECT_EQ(nullptr, clients.clients[0]);
   rmw_reset_error();
 
   // Used a valid wait_set, subscription, guard_conditions, services and clients with no timeout
@@ -305,10 +324,10 @@ TEST_F(CLASSNAME(TestWaitSetUse, RMW_IMPLEMENTATION), rmw_wait)
     &subscriptions, &guard_conditions, &services, &clients, nullptr, wait_set,
     &timeout_argument_zero);
   EXPECT_EQ(ret, RMW_RET_TIMEOUT) << rcutils_get_error_string().str;
-  EXPECT_NE(nullptr, subscriptions.subscribers[0]);
-  EXPECT_NE(nullptr, guard_conditions.guard_conditions[0]);
-  EXPECT_NE(nullptr, services.services[0]);
-  EXPECT_NE(nullptr, clients.clients[0]);
+  EXPECT_EQ(nullptr, subscriptions.subscribers[0]);
+  EXPECT_EQ(nullptr, guard_conditions.guard_conditions[0]);
+  EXPECT_EQ(nullptr, services.services[0]);
+  EXPECT_EQ(nullptr, clients.clients[0]);
   rmw_reset_error();
 
   // Used a valid wait_set, subscription, guard_conditions, services, clients and events with 100ms
@@ -322,11 +341,11 @@ TEST_F(CLASSNAME(TestWaitSetUse, RMW_IMPLEMENTATION), rmw_wait)
     &subscriptions, &guard_conditions, &services, &clients, &events, wait_set,
     &timeout_argument);
   EXPECT_EQ(ret, RMW_RET_TIMEOUT) << rcutils_get_error_string().str;
-  EXPECT_NE(nullptr, subscriptions.subscribers[0]);
-  EXPECT_NE(nullptr, guard_conditions.guard_conditions[0]);
-  EXPECT_NE(nullptr, services.services[0]);
-  EXPECT_NE(nullptr, clients.clients[0]);
-  EXPECT_NE(nullptr, events.events[0]);
+  EXPECT_EQ(nullptr, subscriptions.subscribers[0]);
+  EXPECT_EQ(nullptr, guard_conditions.guard_conditions[0]);
+  EXPECT_EQ(nullptr, services.services[0]);
+  EXPECT_EQ(nullptr, clients.clients[0]);
+  EXPECT_EQ(nullptr, events.events[0]);
   rmw_reset_error();
 
   // Used a valid wait_set, subscription, guard_conditions, services, clients and events with no
@@ -340,30 +359,11 @@ TEST_F(CLASSNAME(TestWaitSetUse, RMW_IMPLEMENTATION), rmw_wait)
     &subscriptions, &guard_conditions, &services, &clients, &events, wait_set,
     &timeout_argument_zero);
   EXPECT_EQ(ret, RMW_RET_TIMEOUT) << rcutils_get_error_string().str;
-  EXPECT_NE(nullptr, subscriptions.subscribers[0]);
-  EXPECT_NE(nullptr, guard_conditions.guard_conditions[0]);
-  EXPECT_NE(nullptr, services.services[0]);
-  EXPECT_NE(nullptr, clients.clients[0]);
-  EXPECT_NE(nullptr, events.events[0]);
-  rmw_reset_error();
-
-  const char * implementation_identifier = wait_set->implementation_identifier;
-  wait_set->implementation_identifier = "not-an-rmw-implementation-identifier";
-  subscriptions.subscribers[0] = sub->data;
-  guard_conditions.guard_conditions[0] = gc->data;
-  services.services[0] = srv->data;
-  clients.clients[0] = client->data;
-  events.events[0] = &event;
-  ret = rmw_wait(
-    &subscriptions, &guard_conditions, &services, &clients, &events, wait_set,
-    &timeout_argument);
-  wait_set->implementation_identifier = implementation_identifier;
-  EXPECT_EQ(ret, RMW_RET_INCORRECT_RMW_IMPLEMENTATION) << rcutils_get_error_string().str;
-  EXPECT_NE(nullptr, subscriptions.subscribers[0]);
-  EXPECT_NE(nullptr, guard_conditions.guard_conditions[0]);
-  EXPECT_NE(nullptr, services.services[0]);
-  EXPECT_NE(nullptr, clients.clients[0]);
-  EXPECT_NE(nullptr, events.events[0]);
+  EXPECT_EQ(nullptr, subscriptions.subscribers[0]);
+  EXPECT_EQ(nullptr, guard_conditions.guard_conditions[0]);
+  EXPECT_EQ(nullptr, services.services[0]);
+  EXPECT_EQ(nullptr, clients.clients[0]);
+  EXPECT_EQ(nullptr, events.events[0]);
   rmw_reset_error();
 
   // Battle test rmw_wait.
@@ -378,13 +378,16 @@ TEST_F(CLASSNAME(TestWaitSetUse, RMW_IMPLEMENTATION), rmw_wait)
       &subscriptions, &guard_conditions, &services, &clients, &events, wait_set,
       &timeout_argument);
 
-    EXPECT_TRUE(RMW_RET_TIMEOUT == ret || RMW_RET_ERROR == ret);
-    EXPECT_NE(nullptr, subscriptions.subscribers[0]);
-    EXPECT_NE(nullptr, guard_conditions.guard_conditions[0]);
-    EXPECT_NE(nullptr, services.services[0]);
-    EXPECT_NE(nullptr, clients.clients[0]);
-    EXPECT_NE(nullptr, events.events[0]);
-    rmw_reset_error();
+    if (RMW_RET_TIMEOUT == ret) {
+      EXPECT_EQ(nullptr, subscriptions.subscribers[0]);
+      EXPECT_EQ(nullptr, guard_conditions.guard_conditions[0]);
+      EXPECT_EQ(nullptr, services.services[0]);
+      EXPECT_EQ(nullptr, clients.clients[0]);
+      EXPECT_EQ(nullptr, events.events[0]);
+    } else {
+      EXPECT_EQ(RMW_RET_ERROR, ret);
+      rmw_reset_error();
+    }
   });
 }
 

--- a/test_rmw_implementation/test/test_wait_set.cpp
+++ b/test_rmw_implementation/test/test_wait_set.cpp
@@ -99,13 +99,14 @@ TEST_F(CLASSNAME(TestWaitSet, RMW_IMPLEMENTATION), rmw_create_wait_set)
   });
 }
 
-class CLASSNAME (TestWaitSetUse, RMW_IMPLEMENTATION) :
-  public CLASSNAME (TestWaitSet, RMW_IMPLEMENTATION)
+class CLASSNAME (TestWaitSetUse, RMW_IMPLEMENTATION)
+  : public CLASSNAME(TestWaitSet, RMW_IMPLEMENTATION)
 {
- protected:
-  using Base = CLASSNAME (TestWaitSet, RMW_IMPLEMENTATION);
+protected:
+  using Base = CLASSNAME(TestWaitSet, RMW_IMPLEMENTATION);
 
-  void SetUp() override {
+  void SetUp() override
+  {
     Base::SetUp();
     constexpr char node_name[] = "my_node";
     constexpr char node_namespace[] = "/my_ns";
@@ -131,7 +132,8 @@ class CLASSNAME (TestWaitSetUse, RMW_IMPLEMENTATION) :
     EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
   }
 
-  void TearDown() override {
+  void TearDown() override
+  {
     rmw_ret_t ret = rmw_event_fini(&event);
     EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
     ret = rmw_destroy_client(node, client);

--- a/test_rmw_implementation/test/test_wait_set.cpp
+++ b/test_rmw_implementation/test/test_wait_set.cpp
@@ -128,8 +128,8 @@ protected:
     ASSERT_NE(nullptr, srv) << rmw_get_error_string().str;
     client = rmw_create_client(node, service_ts, service_name, &rmw_qos_profile_default);
     ASSERT_NE(nullptr, client) << rmw_get_error_string().str;
-    rmw_ret_t ret = rmw_subscription_event_init(&event, sub, RMW_EVENT_REQUESTED_QOS_INCOMPATIBLE);
-    EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+    rmw_ret_t ret = rmw_subscription_event_init(&event, sub, RMW_EVENT_LIVELINESS_CHANGED);
+    ASSERT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
   }
 
   void TearDown() override


### PR DESCRIPTION
CI up to `test_rmw_implementation` and `rcl`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=12539)](http://ci.ros2.org/job/ci_linux/12539/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7508)](http://ci.ros2.org/job/ci_linux-aarch64/7508/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10251)](http://ci.ros2.org/job/ci_osx/10251/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12460)](http://ci.ros2.org/job/ci_windows/12460/)


