### PR TITLE
Use 10x the intraprocess delay to wait for sent requests.

### DIFF
--- a/test_rmw_implementation/test/test_service.cpp
+++ b/test_rmw_implementation/test/test_service.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
+
 #include <gtest/gtest.h>
 
 #include "osrf_testing_tools_cpp/scope_exit.hpp"
@@ -326,8 +328,11 @@ TEST_F(CLASSNAME(TestService, RMW_IMPLEMENTATION), send_reponse_with_bad_argumen
   srv_array.service_count = 1u;
   srv_array.services = array;
   rmw_time_t timeout;
-  timeout.sec = 0;
-  timeout.nsec = rmw_intraprocess_discovery_delay.count() * 1000;
+  auto rmw_intraprocess_discovery_delay_in_nanoseconds =
+    std::chrono::duration_cast<std::chrono::nanoseconds>(
+      rmw_intraprocess_discovery_delay * 10).count();
+  timeout.sec = rmw_intraprocess_discovery_delay_in_nanoseconds / 1000000000;
+  timeout.nsec = rmw_intraprocess_discovery_delay_in_nanoseconds % 1000000000;
   ret = rmw_wait(nullptr, nullptr, &srv_array, nullptr, nullptr, wait_set, &timeout);
   ASSERT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
   ASSERT_NE(nullptr, srv_array.services[0]);

--- a/test_rmw_implementation/test/test_service.cpp
+++ b/test_rmw_implementation/test/test_service.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <chrono>
-
 #include <gtest/gtest.h>
+
+#include <chrono>
 
 #include "osrf_testing_tools_cpp/scope_exit.hpp"
 

--- a/test_rmw_implementation/test/test_service.cpp
+++ b/test_rmw_implementation/test/test_service.cpp
@@ -330,7 +330,7 @@ TEST_F(CLASSNAME(TestService, RMW_IMPLEMENTATION), send_reponse_with_bad_argumen
   rmw_time_t timeout;
   auto rmw_intraprocess_discovery_delay_in_nanoseconds =
     std::chrono::duration_cast<std::chrono::nanoseconds>(
-      rmw_intraprocess_discovery_delay * 10).count();
+    rmw_intraprocess_discovery_delay * 10).count();
   timeout.sec = rmw_intraprocess_discovery_delay_in_nanoseconds / 1000000000;
   timeout.nsec = rmw_intraprocess_discovery_delay_in_nanoseconds % 1000000000;
   ret = rmw_wait(nullptr, nullptr, &srv_array, nullptr, nullptr, wait_set, &timeout);


### PR DESCRIPTION
Follow-up after #141. 

CI up to `test_rmw_implementation`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=12559)](http://ci.ros2.org/job/ci_linux/12559/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7527)](http://ci.ros2.org/job/ci_linux-aarch64/7527/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10270)](http://ci.ros2.org/job/ci_osx/10270/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12481)](http://ci.ros2.org/job/ci_windows/12481/)

