### PR TITLE
Fix up C functions to never throw.

### DIFF
--- a/rmw_implementation/src/functions.hpp
+++ b/rmw_implementation/src/functions.hpp
@@ -16,6 +16,7 @@
 #define FUNCTIONS_HPP_
 
 #include <memory>
+#include <string>
 
 #include "rcpputils/shared_library.hpp"
 

--- a/rmw_implementation/src/functions.hpp
+++ b/rmw_implementation/src/functions.hpp
@@ -25,7 +25,7 @@ RMW_IMPLEMENTATION_DEFAULT_VISIBILITY
 std::shared_ptr<rcpputils::SharedLibrary> load_library();
 
 RMW_IMPLEMENTATION_DEFAULT_VISIBILITY
-void * lookup_symbol(std::shared_ptr<rcpputils::SharedLibrary> lib, const char * symbol_name);
+void * lookup_symbol(std::shared_ptr<rcpputils::SharedLibrary> lib, const std::string & symbol_name);
 
 #ifdef __cplusplus
 extern "C"

--- a/rmw_implementation/src/functions.hpp
+++ b/rmw_implementation/src/functions.hpp
@@ -25,7 +25,9 @@ RMW_IMPLEMENTATION_DEFAULT_VISIBILITY
 std::shared_ptr<rcpputils::SharedLibrary> load_library();
 
 RMW_IMPLEMENTATION_DEFAULT_VISIBILITY
-void * lookup_symbol(std::shared_ptr<rcpputils::SharedLibrary> lib, const std::string & symbol_name);
+void * lookup_symbol(
+  std::shared_ptr<rcpputils::SharedLibrary> lib,
+  const std::string & symbol_name);
 
 #ifdef __cplusplus
 extern "C"


### PR DESCRIPTION
This will reduce coverage somewhat, as the conditions on which these exceptions are generated cannot be reproduced (yet).

CI up to `rmw_implementation`, `test_rmw_implementation`, and `rcl`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=12685)](http://ci.ros2.org/job/ci_linux/12685/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7648)](http://ci.ros2.org/job/ci_linux-aarch64/7648/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10400)](http://ci.ros2.org/job/ci_osx/10400/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12628)](http://ci.ros2.org/job/ci_windows/12628/)

