### PR TITLE
Add tests bad type_support implementation

### DIFF
--- a/test_rmw_implementation/test/test_client.cpp
+++ b/test_rmw_implementation/test/test_client.cpp
@@ -143,14 +143,14 @@ TEST_F(CLASSNAME(TestClient, RMW_IMPLEMENTATION), create_with_bad_arguments) {
   EXPECT_EQ(nullptr, client);
   rmw_reset_error();
 
-  rosidl_service_type_support_t * non_implementation_ts =
+  rosidl_service_type_support_t * non_const_ts =
     const_cast<rosidl_service_type_support_t *>(ts);
-  const char * old_identifier = non_implementation_ts->typesupport_identifier;
-  non_implementation_ts->typesupport_identifier = "not-an-implementation-identifier";
-  client = rmw_create_client(node, non_implementation_ts, service_name, &rmw_qos_profile_default);
+  const char * old_identifier = non_const_ts->typesupport_identifier;
+  non_const_ts->typesupport_identifier = "not-a-typesupport-identifier";
+  client = rmw_create_client(node, non_const_ts, service_name, &rmw_qos_profile_default);
   EXPECT_EQ(nullptr, client);
   rmw_reset_error();
-  non_implementation_ts->typesupport_identifier = old_identifier;
+  non_const_ts->typesupport_identifier = old_identifier;
 
   // Creating and destroying a client still succeeds.
   client = rmw_create_client(node, ts, service_name, &rmw_qos_profile_default);

--- a/test_rmw_implementation/test/test_client.cpp
+++ b/test_rmw_implementation/test/test_client.cpp
@@ -143,6 +143,14 @@ TEST_F(CLASSNAME(TestClient, RMW_IMPLEMENTATION), create_with_bad_arguments) {
   EXPECT_EQ(nullptr, client);
   rmw_reset_error();
 
+  rosidl_service_type_support_t * non_implementation_ts = const_cast<rosidl_service_type_support_t *>(ts);
+  const char * old_identifier = non_implementation_ts->typesupport_identifier;
+  non_implementation_ts->typesupport_identifier = "not-an-implementation-identifier";
+  client = rmw_create_client(node, non_implementation_ts, service_name, &rmw_qos_profile_default);
+  EXPECT_EQ(nullptr, client);
+  rmw_reset_error();
+  non_implementation_ts->typesupport_identifier = old_identifier;
+
   // Creating and destroying a client still succeeds.
   client = rmw_create_client(node, ts, service_name, &rmw_qos_profile_default);
   ASSERT_NE(nullptr, client) << rmw_get_error_string().str;

--- a/test_rmw_implementation/test/test_client.cpp
+++ b/test_rmw_implementation/test/test_client.cpp
@@ -145,12 +145,12 @@ TEST_F(CLASSNAME(TestClient, RMW_IMPLEMENTATION), create_with_bad_arguments) {
 
   rosidl_service_type_support_t * non_const_ts =
     const_cast<rosidl_service_type_support_t *>(ts);
-  const char * old_identifier = non_const_ts->typesupport_identifier;
+  const char * typesupport_identifier = non_const_ts->typesupport_identifier;
   non_const_ts->typesupport_identifier = "not-a-typesupport-identifier";
   client = rmw_create_client(node, non_const_ts, service_name, &rmw_qos_profile_default);
   EXPECT_EQ(nullptr, client);
   rmw_reset_error();
-  non_const_ts->typesupport_identifier = old_identifier;
+  non_const_ts->typesupport_identifier = typesupport_identifier;
 
   // Creating and destroying a client still succeeds.
   client = rmw_create_client(node, ts, service_name, &rmw_qos_profile_default);

--- a/test_rmw_implementation/test/test_client.cpp
+++ b/test_rmw_implementation/test/test_client.cpp
@@ -143,7 +143,8 @@ TEST_F(CLASSNAME(TestClient, RMW_IMPLEMENTATION), create_with_bad_arguments) {
   EXPECT_EQ(nullptr, client);
   rmw_reset_error();
 
-  rosidl_service_type_support_t * non_implementation_ts = const_cast<rosidl_service_type_support_t *>(ts);
+  rosidl_service_type_support_t * non_implementation_ts =
+    const_cast<rosidl_service_type_support_t *>(ts);
   const char * old_identifier = non_implementation_ts->typesupport_identifier;
   non_implementation_ts->typesupport_identifier = "not-an-implementation-identifier";
   client = rmw_create_client(node, non_implementation_ts, service_name, &rmw_qos_profile_default);

--- a/test_rmw_implementation/test/test_publisher.cpp
+++ b/test_rmw_implementation/test/test_publisher.cpp
@@ -147,7 +147,8 @@ TEST_F(CLASSNAME(TestPublisher, RMW_IMPLEMENTATION), create_with_bad_arguments) 
   EXPECT_EQ(nullptr, pub);
   rmw_reset_error();
 
-  rosidl_message_type_support_t * non_implementation_ts = const_cast<rosidl_message_type_support_t *>(ts);
+  rosidl_message_type_support_t * non_implementation_ts =
+    const_cast<rosidl_message_type_support_t *>(ts);
   const char * old_identifier = non_implementation_ts->typesupport_identifier;
   non_implementation_ts->typesupport_identifier = "not-an-implementation-identifier";
   pub = rmw_create_publisher(node, ts, topic_name, &rmw_qos_profile_default, &options);

--- a/test_rmw_implementation/test/test_publisher.cpp
+++ b/test_rmw_implementation/test/test_publisher.cpp
@@ -147,6 +147,14 @@ TEST_F(CLASSNAME(TestPublisher, RMW_IMPLEMENTATION), create_with_bad_arguments) 
   EXPECT_EQ(nullptr, pub);
   rmw_reset_error();
 
+  rosidl_message_type_support_t * non_implementation_ts = const_cast<rosidl_message_type_support_t *>(ts);
+  const char * old_identifier = non_implementation_ts->typesupport_identifier;
+  non_implementation_ts->typesupport_identifier = "not-an-implementation-identifier";
+  pub = rmw_create_publisher(node, ts, topic_name, &rmw_qos_profile_default, &options);
+  EXPECT_EQ(nullptr, pub);
+  rmw_reset_error();
+  non_implementation_ts->typesupport_identifier = old_identifier;
+
   // Creating and destroying a publisher still succeeds.
   pub = rmw_create_publisher(node, ts, topic_name, &rmw_qos_profile_default, &options);
   ASSERT_NE(nullptr, pub) << rmw_get_error_string().str;

--- a/test_rmw_implementation/test/test_publisher.cpp
+++ b/test_rmw_implementation/test/test_publisher.cpp
@@ -149,12 +149,12 @@ TEST_F(CLASSNAME(TestPublisher, RMW_IMPLEMENTATION), create_with_bad_arguments) 
 
   rosidl_message_type_support_t * non_const_ts =
     const_cast<rosidl_message_type_support_t *>(ts);
-  const char * old_identifier = non_const_ts->typesupport_identifier;
+  const char * typesupport_identifier = non_const_ts->typesupport_identifier;
   non_const_ts->typesupport_identifier = "not-a-typesupport-identifier";
   pub = rmw_create_publisher(node, non_const_ts, topic_name, &rmw_qos_profile_default, &options);
   EXPECT_EQ(nullptr, pub);
   rmw_reset_error();
-  non_const_ts->typesupport_identifier = old_identifier;
+  non_const_ts->typesupport_identifier = typesupport_identifier;
 
   // Creating and destroying a publisher still succeeds.
   pub = rmw_create_publisher(node, ts, topic_name, &rmw_qos_profile_default, &options);

--- a/test_rmw_implementation/test/test_publisher.cpp
+++ b/test_rmw_implementation/test/test_publisher.cpp
@@ -147,14 +147,14 @@ TEST_F(CLASSNAME(TestPublisher, RMW_IMPLEMENTATION), create_with_bad_arguments) 
   EXPECT_EQ(nullptr, pub);
   rmw_reset_error();
 
-  rosidl_message_type_support_t * non_implementation_ts =
+  rosidl_message_type_support_t * non_const_ts =
     const_cast<rosidl_message_type_support_t *>(ts);
-  const char * old_identifier = non_implementation_ts->typesupport_identifier;
-  non_implementation_ts->typesupport_identifier = "not-an-implementation-identifier";
-  pub = rmw_create_publisher(node, ts, topic_name, &rmw_qos_profile_default, &options);
+  const char * old_identifier = non_const_ts->typesupport_identifier;
+  non_const_ts->typesupport_identifier = "not-a-typesupport-identifier";
+  pub = rmw_create_publisher(node, non_const_ts, topic_name, &rmw_qos_profile_default, &options);
   EXPECT_EQ(nullptr, pub);
   rmw_reset_error();
-  non_implementation_ts->typesupport_identifier = old_identifier;
+  non_const_ts->typesupport_identifier = old_identifier;
 
   // Creating and destroying a publisher still succeeds.
   pub = rmw_create_publisher(node, ts, topic_name, &rmw_qos_profile_default, &options);

--- a/test_rmw_implementation/test/test_serialize_deserialize.cpp
+++ b/test_rmw_implementation/test/test_serialize_deserialize.cpp
@@ -57,6 +57,17 @@ TEST_F(CLASSNAME(TestSerializeDeserialize, RMW_IMPLEMENTATION), serialize_with_b
   EXPECT_NE(RMW_RET_OK, rmw_serialize(&input_message, ts, &serialized_message));
   rmw_reset_error();
 
+  rosidl_message_type_support_t * non_implementation_ts = const_cast<rosidl_message_type_support_t *>(ts);
+  const char * old_identifier = non_implementation_ts->typesupport_identifier;
+  non_implementation_ts->typesupport_identifier = "not-an-implementation-identifier";
+  rcutils_allocator_t default_allocator = rcutils_get_default_allocator();
+  ASSERT_EQ(
+    RMW_RET_OK, rmw_serialized_message_init(
+      &serialized_message, 0lu, &default_allocator)) << rmw_get_error_string().str;
+  EXPECT_NE(RMW_RET_OK, rmw_serialize(&input_message, non_implementation_ts, &serialized_message));
+  rmw_reset_error();
+  non_implementation_ts->typesupport_identifier = old_identifier;
+
   EXPECT_EQ(RMW_RET_OK, rmw_serialized_message_fini(&serialized_message)) <<
     rmw_get_error_string().str;
 }

--- a/test_rmw_implementation/test/test_serialize_deserialize.cpp
+++ b/test_rmw_implementation/test/test_serialize_deserialize.cpp
@@ -57,16 +57,22 @@ TEST_F(CLASSNAME(TestSerializeDeserialize, RMW_IMPLEMENTATION), serialize_with_b
   EXPECT_NE(RMW_RET_OK, rmw_serialize(&input_message, ts, &serialized_message));
   rmw_reset_error();
 
-  rosidl_message_type_support_t * non_const_ts =
-    const_cast<rosidl_message_type_support_t *>(ts);
-  const char * typesupport_identifier = non_const_ts->typesupport_identifier;
-  non_const_ts->typesupport_identifier = "not-a-typesupport-identifier";
+  EXPECT_EQ(RMW_RET_OK, rmw_serialized_message_fini(&serialized_message)) <<
+    rmw_get_error_string().str;
+
   rcutils_allocator_t default_allocator = rcutils_get_default_allocator();
   ASSERT_EQ(
     RMW_RET_OK, rmw_serialized_message_init(
       &serialized_message, 0lu, &default_allocator)) << rmw_get_error_string().str;
+
+  rosidl_message_type_support_t * non_const_ts =
+    const_cast<rosidl_message_type_support_t *>(ts);
+  const char * typesupport_identifier = non_const_ts->typesupport_identifier;
+  non_const_ts->typesupport_identifier = "not-a-typesupport-identifier";
+
   EXPECT_NE(RMW_RET_OK, rmw_serialize(&input_message, non_const_ts, &serialized_message));
   rmw_reset_error();
+
   non_const_ts->typesupport_identifier = typesupport_identifier;
 
   EXPECT_EQ(RMW_RET_OK, rmw_serialized_message_fini(&serialized_message)) <<

--- a/test_rmw_implementation/test/test_serialize_deserialize.cpp
+++ b/test_rmw_implementation/test/test_serialize_deserialize.cpp
@@ -57,17 +57,17 @@ TEST_F(CLASSNAME(TestSerializeDeserialize, RMW_IMPLEMENTATION), serialize_with_b
   EXPECT_NE(RMW_RET_OK, rmw_serialize(&input_message, ts, &serialized_message));
   rmw_reset_error();
 
-  rosidl_message_type_support_t * non_implementation_ts =
+  rosidl_message_type_support_t * non_const_ts =
     const_cast<rosidl_message_type_support_t *>(ts);
-  const char * old_identifier = non_implementation_ts->typesupport_identifier;
-  non_implementation_ts->typesupport_identifier = "not-an-implementation-identifier";
+  const char * old_identifier = non_const_ts->typesupport_identifier;
+  non_const_ts->typesupport_identifier = "not-a-typesupport-identifier";
   rcutils_allocator_t default_allocator = rcutils_get_default_allocator();
   ASSERT_EQ(
     RMW_RET_OK, rmw_serialized_message_init(
       &serialized_message, 0lu, &default_allocator)) << rmw_get_error_string().str;
-  EXPECT_NE(RMW_RET_OK, rmw_serialize(&input_message, non_implementation_ts, &serialized_message));
+  EXPECT_NE(RMW_RET_OK, rmw_serialize(&input_message, non_const_ts, &serialized_message));
   rmw_reset_error();
-  non_implementation_ts->typesupport_identifier = old_identifier;
+  non_const_ts->typesupport_identifier = old_identifier;
 
   EXPECT_EQ(RMW_RET_OK, rmw_serialized_message_fini(&serialized_message)) <<
     rmw_get_error_string().str;

--- a/test_rmw_implementation/test/test_serialize_deserialize.cpp
+++ b/test_rmw_implementation/test/test_serialize_deserialize.cpp
@@ -59,7 +59,7 @@ TEST_F(CLASSNAME(TestSerializeDeserialize, RMW_IMPLEMENTATION), serialize_with_b
 
   rosidl_message_type_support_t * non_const_ts =
     const_cast<rosidl_message_type_support_t *>(ts);
-  const char * old_identifier = non_const_ts->typesupport_identifier;
+  const char * typesupport_identifier = non_const_ts->typesupport_identifier;
   non_const_ts->typesupport_identifier = "not-a-typesupport-identifier";
   rcutils_allocator_t default_allocator = rcutils_get_default_allocator();
   ASSERT_EQ(
@@ -67,7 +67,7 @@ TEST_F(CLASSNAME(TestSerializeDeserialize, RMW_IMPLEMENTATION), serialize_with_b
       &serialized_message, 0lu, &default_allocator)) << rmw_get_error_string().str;
   EXPECT_NE(RMW_RET_OK, rmw_serialize(&input_message, non_const_ts, &serialized_message));
   rmw_reset_error();
-  non_const_ts->typesupport_identifier = old_identifier;
+  non_const_ts->typesupport_identifier = typesupport_identifier;
 
   EXPECT_EQ(RMW_RET_OK, rmw_serialized_message_fini(&serialized_message)) <<
     rmw_get_error_string().str;

--- a/test_rmw_implementation/test/test_serialize_deserialize.cpp
+++ b/test_rmw_implementation/test/test_serialize_deserialize.cpp
@@ -57,7 +57,8 @@ TEST_F(CLASSNAME(TestSerializeDeserialize, RMW_IMPLEMENTATION), serialize_with_b
   EXPECT_NE(RMW_RET_OK, rmw_serialize(&input_message, ts, &serialized_message));
   rmw_reset_error();
 
-  rosidl_message_type_support_t * non_implementation_ts = const_cast<rosidl_message_type_support_t *>(ts);
+  rosidl_message_type_support_t * non_implementation_ts =
+    const_cast<rosidl_message_type_support_t *>(ts);
   const char * old_identifier = non_implementation_ts->typesupport_identifier;
   non_implementation_ts->typesupport_identifier = "not-an-implementation-identifier";
   rcutils_allocator_t default_allocator = rcutils_get_default_allocator();

--- a/test_rmw_implementation/test/test_service.cpp
+++ b/test_rmw_implementation/test/test_service.cpp
@@ -146,12 +146,12 @@ TEST_F(CLASSNAME(TestService, RMW_IMPLEMENTATION), create_with_bad_arguments) {
 
   rosidl_service_type_support_t * non_const_ts =
     const_cast<rosidl_service_type_support_t *>(ts);
-  const char * old_identifier = non_const_ts->typesupport_identifier;
+  const char * typesupport_identifier = non_const_ts->typesupport_identifier;
   non_const_ts->typesupport_identifier = "not-a-typesupport-identifier";
   srv = rmw_create_service(node, non_const_ts, service_name, &rmw_qos_profile_default);
   EXPECT_EQ(nullptr, srv);
   rmw_reset_error();
-  non_const_ts->typesupport_identifier = old_identifier;
+  non_const_ts->typesupport_identifier = typesupport_identifier;
 
   // Creating and destroying a service still succeeds.
   srv = rmw_create_service(node, ts, service_name, &rmw_qos_profile_default);

--- a/test_rmw_implementation/test/test_service.cpp
+++ b/test_rmw_implementation/test/test_service.cpp
@@ -144,6 +144,14 @@ TEST_F(CLASSNAME(TestService, RMW_IMPLEMENTATION), create_with_bad_arguments) {
   EXPECT_EQ(nullptr, srv);
   rmw_reset_error();
 
+  rosidl_service_type_support_t * non_implementation_ts = const_cast<rosidl_service_type_support_t *>(ts);
+  const char * old_identifier = non_implementation_ts->typesupport_identifier;
+  non_implementation_ts->typesupport_identifier = "not-an-implementation-identifier";
+  srv = rmw_create_service(node, non_implementation_ts, service_name, &rmw_qos_profile_default);
+  EXPECT_EQ(nullptr, srv);
+  rmw_reset_error();
+  non_implementation_ts->typesupport_identifier = old_identifier;
+
   // Creating and destroying a service still succeeds.
   srv = rmw_create_service(node, ts, service_name, &rmw_qos_profile_default);
   ASSERT_NE(nullptr, srv) << rmw_get_error_string().str;

--- a/test_rmw_implementation/test/test_service.cpp
+++ b/test_rmw_implementation/test/test_service.cpp
@@ -144,7 +144,8 @@ TEST_F(CLASSNAME(TestService, RMW_IMPLEMENTATION), create_with_bad_arguments) {
   EXPECT_EQ(nullptr, srv);
   rmw_reset_error();
 
-  rosidl_service_type_support_t * non_implementation_ts = const_cast<rosidl_service_type_support_t *>(ts);
+  rosidl_service_type_support_t * non_implementation_ts =
+    const_cast<rosidl_service_type_support_t *>(ts);
   const char * old_identifier = non_implementation_ts->typesupport_identifier;
   non_implementation_ts->typesupport_identifier = "not-an-implementation-identifier";
   srv = rmw_create_service(node, non_implementation_ts, service_name, &rmw_qos_profile_default);

--- a/test_rmw_implementation/test/test_service.cpp
+++ b/test_rmw_implementation/test/test_service.cpp
@@ -144,14 +144,14 @@ TEST_F(CLASSNAME(TestService, RMW_IMPLEMENTATION), create_with_bad_arguments) {
   EXPECT_EQ(nullptr, srv);
   rmw_reset_error();
 
-  rosidl_service_type_support_t * non_implementation_ts =
+  rosidl_service_type_support_t * non_const_ts =
     const_cast<rosidl_service_type_support_t *>(ts);
-  const char * old_identifier = non_implementation_ts->typesupport_identifier;
-  non_implementation_ts->typesupport_identifier = "not-an-implementation-identifier";
-  srv = rmw_create_service(node, non_implementation_ts, service_name, &rmw_qos_profile_default);
+  const char * old_identifier = non_const_ts->typesupport_identifier;
+  non_const_ts->typesupport_identifier = "not-a-typesupport-identifier";
+  srv = rmw_create_service(node, non_const_ts, service_name, &rmw_qos_profile_default);
   EXPECT_EQ(nullptr, srv);
   rmw_reset_error();
-  non_implementation_ts->typesupport_identifier = old_identifier;
+  non_const_ts->typesupport_identifier = old_identifier;
 
   // Creating and destroying a service still succeeds.
   srv = rmw_create_service(node, ts, service_name, &rmw_qos_profile_default);

--- a/test_rmw_implementation/test/test_subscription.cpp
+++ b/test_rmw_implementation/test/test_subscription.cpp
@@ -152,14 +152,14 @@ TEST_F(CLASSNAME(TestSubscription, RMW_IMPLEMENTATION), create_with_bad_argument
 
   rosidl_message_type_support_t * non_const_ts =
     const_cast<rosidl_message_type_support_t *>(ts);
-  const char * old_identifier = non_const_ts->typesupport_identifier;
+  const char * typesupport_identifier = non_const_ts->typesupport_identifier;
   non_const_ts->typesupport_identifier = "not-a-typesupport-identifier";
   sub = rmw_create_subscription(
     node, non_const_ts, topic_name,
     &rmw_qos_profile_default, &options);
   EXPECT_EQ(nullptr, sub);
   rmw_reset_error();
-  non_const_ts->typesupport_identifier = old_identifier;
+  non_const_ts->typesupport_identifier = typesupport_identifier;
 
   // Creating and destroying a subscription still succeeds.
   sub = rmw_create_subscription(node, ts, topic_name, &rmw_qos_profile_default, &options);

--- a/test_rmw_implementation/test/test_subscription.cpp
+++ b/test_rmw_implementation/test/test_subscription.cpp
@@ -150,16 +150,16 @@ TEST_F(CLASSNAME(TestSubscription, RMW_IMPLEMENTATION), create_with_bad_argument
   EXPECT_EQ(nullptr, sub);
   rmw_reset_error();
 
-  rosidl_message_type_support_t * non_implementation_ts =
+  rosidl_message_type_support_t * non_const_ts =
     const_cast<rosidl_message_type_support_t *>(ts);
-  const char * old_identifier = non_implementation_ts->typesupport_identifier;
-  non_implementation_ts->typesupport_identifier = "not-an-implementation-identifier";
+  const char * old_identifier = non_const_ts->typesupport_identifier;
+  non_const_ts->typesupport_identifier = "not-a-typesupport-identifier";
   sub = rmw_create_subscription(
-    node, non_implementation_ts, topic_name,
+    node, non_const_ts, topic_name,
     &rmw_qos_profile_default, &options);
   EXPECT_EQ(nullptr, sub);
   rmw_reset_error();
-  non_implementation_ts->typesupport_identifier = old_identifier;
+  non_const_ts->typesupport_identifier = old_identifier;
 
   // Creating and destroying a subscription still succeeds.
   sub = rmw_create_subscription(node, ts, topic_name, &rmw_qos_profile_default, &options);

--- a/test_rmw_implementation/test/test_subscription.cpp
+++ b/test_rmw_implementation/test/test_subscription.cpp
@@ -150,10 +150,13 @@ TEST_F(CLASSNAME(TestSubscription, RMW_IMPLEMENTATION), create_with_bad_argument
   EXPECT_EQ(nullptr, sub);
   rmw_reset_error();
 
-  rosidl_message_type_support_t * non_implementation_ts = const_cast<rosidl_message_type_support_t *>(ts);
+  rosidl_message_type_support_t * non_implementation_ts =
+    const_cast<rosidl_message_type_support_t *>(ts);
   const char * old_identifier = non_implementation_ts->typesupport_identifier;
   non_implementation_ts->typesupport_identifier = "not-an-implementation-identifier";
-  sub = rmw_create_subscription(node, non_implementation_ts, topic_name, &rmw_qos_profile_default, &options);
+  sub = rmw_create_subscription(
+    node, non_implementation_ts, topic_name,
+    &rmw_qos_profile_default, &options);
   EXPECT_EQ(nullptr, sub);
   rmw_reset_error();
   non_implementation_ts->typesupport_identifier = old_identifier;

--- a/test_rmw_implementation/test/test_subscription.cpp
+++ b/test_rmw_implementation/test/test_subscription.cpp
@@ -150,6 +150,14 @@ TEST_F(CLASSNAME(TestSubscription, RMW_IMPLEMENTATION), create_with_bad_argument
   EXPECT_EQ(nullptr, sub);
   rmw_reset_error();
 
+  rosidl_message_type_support_t * non_implementation_ts = const_cast<rosidl_message_type_support_t *>(ts);
+  const char * old_identifier = non_implementation_ts->typesupport_identifier;
+  non_implementation_ts->typesupport_identifier = "not-an-implementation-identifier";
+  sub = rmw_create_subscription(node, non_implementation_ts, topic_name, &rmw_qos_profile_default, &options);
+  EXPECT_EQ(nullptr, sub);
+  rmw_reset_error();
+  non_implementation_ts->typesupport_identifier = old_identifier;
+
   // Creating and destroying a subscription still succeeds.
   sub = rmw_create_subscription(node, ts, topic_name, &rmw_qos_profile_default, &options);
   ASSERT_NE(nullptr, sub) << rmw_get_error_string().str;


### PR DESCRIPTION
This tests should add 10 lines of coverage to `rmw_fastrtps_cpp`
Signed-off-by: lobotuerk <jtlorente@ekumenlabs.com>