### PR TITLE
Add EventsExecutor

### DIFF
--- a/rmw_implementation/src/functions.cpp
+++ b/rmw_implementation/src/functions.cpp
@@ -698,6 +698,36 @@ RMW_INTERFACE_FN(
     rcutils_allocator_t *,
     rmw_network_flow_endpoint_array_t *))
 
+RMW_INTERFACE_FN(
+  rmw_subscription_set_listener_callback,
+  rmw_ret_t, RMW_RET_ERROR,
+  3, ARG_TYPES(
+    rmw_subscription_t *, rmw_listener_callback_t, const void *))
+
+RMW_INTERFACE_FN(
+  rmw_service_set_listener_callback,
+  rmw_ret_t, RMW_RET_ERROR,
+  3, ARG_TYPES(
+    rmw_service_t *, rmw_listener_callback_t, const void *))
+
+RMW_INTERFACE_FN(
+  rmw_client_set_listener_callback,
+  rmw_ret_t, RMW_RET_ERROR,
+  3, ARG_TYPES(
+    rmw_client_t *, rmw_listener_callback_t, const void *))
+
+RMW_INTERFACE_FN(
+  rmw_guard_condition_set_listener_callback,
+  rmw_ret_t, RMW_RET_ERROR,
+  4, ARG_TYPES(
+    rmw_guard_condition_t *, rmw_listener_callback_t, const void *, bool))
+
+RMW_INTERFACE_FN(
+  rmw_event_set_listener_callback,
+  rmw_ret_t, RMW_RET_ERROR,
+  4, ARG_TYPES(
+    rmw_event_t *, rmw_listener_callback_t, const void *, bool))
+
 #define GET_SYMBOL(x) symbol_ ## x = get_symbol(#x);
 
 void prefetch_symbols(void)
@@ -783,6 +813,11 @@ void prefetch_symbols(void)
   GET_SYMBOL(rmw_subscription_get_network_flow_endpoints)
   GET_SYMBOL(rmw_client_request_publisher_get_actual_qos);
   GET_SYMBOL(rmw_client_response_subscription_get_actual_qos);
+  GET_SYMBOL(rmw_subscription_set_listener_callback)
+  GET_SYMBOL(rmw_service_set_listener_callback)
+  GET_SYMBOL(rmw_client_set_listener_callback)
+  GET_SYMBOL(rmw_guard_condition_set_listener_callback)
+  GET_SYMBOL(rmw_event_set_listener_callback)
 }
 
 void * symbol_rmw_init = nullptr;

--- a/rmw_implementation/src/functions.cpp
+++ b/rmw_implementation/src/functions.cpp
@@ -719,14 +719,14 @@ RMW_INTERFACE_FN(
 RMW_INTERFACE_FN(
   rmw_guard_condition_set_listener_callback,
   rmw_ret_t, RMW_RET_ERROR,
-  4, ARG_TYPES(
-    rmw_guard_condition_t *, rmw_listener_callback_t, const void *, bool))
+  3, ARG_TYPES(
+    rmw_guard_condition_t *, rmw_listener_callback_t, const void *))
 
 RMW_INTERFACE_FN(
   rmw_event_set_listener_callback,
   rmw_ret_t, RMW_RET_ERROR,
-  4, ARG_TYPES(
-    rmw_event_t *, rmw_listener_callback_t, const void *, bool))
+  3, ARG_TYPES(
+    rmw_event_t *, rmw_listener_callback_t, const void *))
 
 #define GET_SYMBOL(x) symbol_ ## x = get_symbol(#x);
 

--- a/rmw_implementation/src/functions.cpp
+++ b/rmw_implementation/src/functions.cpp
@@ -699,28 +699,28 @@ RMW_INTERFACE_FN(
     rmw_network_flow_endpoint_array_t *))
 
 RMW_INTERFACE_FN(
-  rmw_subscription_set_listener_callback,
+  rmw_subscription_set_on_new_message_callback,
   rmw_ret_t, RMW_RET_ERROR,
   3, ARG_TYPES(
-    rmw_subscription_t *, rmw_listener_callback_t, const void *))
+    rmw_subscription_t *, rmw_event_callback_t, const void *))
 
 RMW_INTERFACE_FN(
-  rmw_service_set_listener_callback,
+  rmw_service_set_on_new_request_callback,
   rmw_ret_t, RMW_RET_ERROR,
   3, ARG_TYPES(
-    rmw_service_t *, rmw_listener_callback_t, const void *))
+    rmw_service_t *, rmw_event_callback_t, const void *))
 
 RMW_INTERFACE_FN(
-  rmw_client_set_listener_callback,
+  rmw_client_set_on_new_response_callback,
   rmw_ret_t, RMW_RET_ERROR,
   3, ARG_TYPES(
-    rmw_client_t *, rmw_listener_callback_t, const void *))
+    rmw_client_t *, rmw_event_callback_t, const void *))
 
 RMW_INTERFACE_FN(
-  rmw_event_set_listener_callback,
+  rmw_event_set_callback,
   rmw_ret_t, RMW_RET_ERROR,
   3, ARG_TYPES(
-    rmw_event_t *, rmw_listener_callback_t, const void *))
+    rmw_event_t *, rmw_event_callback_t, const void *))
 
 #define GET_SYMBOL(x) symbol_ ## x = get_symbol(#x);
 
@@ -807,10 +807,10 @@ void prefetch_symbols(void)
   GET_SYMBOL(rmw_subscription_get_network_flow_endpoints)
   GET_SYMBOL(rmw_client_request_publisher_get_actual_qos);
   GET_SYMBOL(rmw_client_response_subscription_get_actual_qos);
-  GET_SYMBOL(rmw_subscription_set_listener_callback)
-  GET_SYMBOL(rmw_service_set_listener_callback)
-  GET_SYMBOL(rmw_client_set_listener_callback)
-  GET_SYMBOL(rmw_event_set_listener_callback)
+  GET_SYMBOL(rmw_subscription_set_on_new_message_callback)
+  GET_SYMBOL(rmw_service_set_on_new_request_callback)
+  GET_SYMBOL(rmw_client_set_on_new_response_callback)
+  GET_SYMBOL(rmw_event_set_callback)
 }
 
 void * symbol_rmw_init = nullptr;
@@ -919,5 +919,9 @@ unload_library()
   symbol_rmw_publisher_get_network_flow_endpoints = nullptr;
   symbol_rmw_subscription_get_network_flow_endpoints = nullptr;
   symbol_rmw_init = nullptr;
+  symbol_rmw_subscription_set_on_new_message_callback = nullptr;
+  symbol_rmw_service_set_on_new_request_callback = nullptr;
+  symbol_rmw_client_set_on_new_response_callback = nullptr;
+  symbol_rmw_event_set_callback = nullptr;
   g_rmw_lib.reset();
 }

--- a/rmw_implementation/src/functions.cpp
+++ b/rmw_implementation/src/functions.cpp
@@ -717,12 +717,6 @@ RMW_INTERFACE_FN(
     rmw_client_t *, rmw_listener_callback_t, const void *))
 
 RMW_INTERFACE_FN(
-  rmw_guard_condition_set_listener_callback,
-  rmw_ret_t, RMW_RET_ERROR,
-  3, ARG_TYPES(
-    rmw_guard_condition_t *, rmw_listener_callback_t, const void *))
-
-RMW_INTERFACE_FN(
   rmw_event_set_listener_callback,
   rmw_ret_t, RMW_RET_ERROR,
   3, ARG_TYPES(
@@ -816,7 +810,6 @@ void prefetch_symbols(void)
   GET_SYMBOL(rmw_subscription_set_listener_callback)
   GET_SYMBOL(rmw_service_set_listener_callback)
   GET_SYMBOL(rmw_client_set_listener_callback)
-  GET_SYMBOL(rmw_guard_condition_set_listener_callback)
   GET_SYMBOL(rmw_event_set_listener_callback)
 }
 


### PR DESCRIPTION
This PR introduces the changes required to implement the `EventsExecutor` design in rmw.
See [design](https://github.com/ros2/design/pull/305) and [Discourse post](https://discourse.ros.org/t/ros2-middleware-change-proposal/15863).

The new executor uses an events queue and a timers manager as opposed to waitsets, to efficiently execute entities with work to do.

This new executor greatly reduces CPU usage of a ROS 2 application.
See the blog post for more details on the tests that we run.

The bulk of the changes for this implementation are in the rclcpp layer, with some minor changes in other repositories (rcl, rmw, rmw_implementation) for forwarding entities, the declaration of some data types in rcutils, and finally some additional changes in the vendor specific rmw implementations..
We currently implemented this only on top of the default ROS middleware fastrtps, while we provided stubs for other middlewares.

See the main PR to rclcpp https://github.com/ros2/rclcpp/pull/1416.

The current implementation does not support ROS 2 actions, which will be added in a follow up PR.

Developed by iRobot
Mauro Passerino
Lenny Story
Alberto Soragna

----

Connects to:

- design:
  - https://github.com/ros2/design/pull/305