### PR TITLE
Add some additional checking that cleanup happens.

### DIFF
--- a/test_rmw_implementation/test/test_service.cpp
+++ b/test_rmw_implementation/test/test_service.cpp
@@ -486,6 +486,7 @@ TEST_F(CLASSNAME(TestService, RMW_IMPLEMENTATION), send_reponse_with_client_gone
 
   // Remove client
   ret = rmw_destroy_client(node, client);
+  EXPECT_EQ(RMW_RET_OK, ret);
   destroy_client = false;
 
   // RMW_RET_OK is returned even if the client is gone

--- a/test_rmw_implementation/test/test_wait_set.cpp
+++ b/test_rmw_implementation/test/test_wait_set.cpp
@@ -144,6 +144,7 @@ protected:
     ret = rmw_destroy_guard_condition(gc);
     EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
     ret = rmw_destroy_node(node);
+    EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
     Base::TearDown();
   }
 


### PR DESCRIPTION
Pointed out by clang static analysis.  This is just a little
more correct.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>