### PR TITLE
Defer path resolution of rmw implementation libraries to dynamic linker.

### DIFF
--- a/rmw_implementation/src/functions.cpp
+++ b/rmw_implementation/src/functions.cpp
@@ -25,7 +25,6 @@
 #include "rcutils/get_env.h"
 #include "rcutils/types/string_array.h"
 
-#include "rcpputils/find_library.hpp"
 #include "rcpputils/get_env.hpp"
 #include "rcpputils/shared_library.hpp"
 
@@ -60,28 +59,21 @@ load_library()
     env_var = STRINGIFY(DEFAULT_RMW_IMPLEMENTATION);
   }
 
-  std::string library_path;
+  std::string library_name;
   try {
-    library_path = rcpputils::find_library_path(env_var);
+    library_name = rcpputils::get_platform_library_name(env_var);
   } catch (const std::exception & e) {
     RMW_SET_ERROR_MSG_WITH_FORMAT_STRING(
-      "failed to find shared library due to %s", e.what());
-    return nullptr;
-  }
-
-  if (library_path.empty()) {
-    RMW_SET_ERROR_MSG_WITH_FORMAT_STRING(
-      "failed to find shared library '%s'",
-      env_var.c_str());
+      "failed to compute shared library name due to %s", e.what());
     return nullptr;
   }
 
   try {
-    return std::make_shared<rcpputils::SharedLibrary>(library_path.c_str());
+    return std::make_shared<rcpputils::SharedLibrary>(library_name);
   } catch (const std::exception & e) {
     RMW_SET_ERROR_MSG_WITH_FORMAT_STRING(
       "failed to load shared library '%s' due to %s",
-      library_path.c_str(), e.what());
+      library_name.c_str(), e.what());
     return nullptr;
   }
 }


### PR DESCRIPTION
Connected to https://github.com/ros2/rcutils/pull/320. By deferring path resolution to the dynamic linker, RPATHs and RUNPATHs entries as well as LD_LIBRARY_PATH and PATH envvars are dealt with the standard way. Pre-linked and pre-loaded libraries are also honored. 

CI up to `test_communication`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13267)](http://ci.ros2.org/job/ci_linux/13267/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8198)](http://ci.ros2.org/job/ci_linux-aarch64/8198/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10987)](http://ci.ros2.org/job/ci_osx/10987/) (known test failure)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13310)](http://ci.ros2.org/job/ci_windows/13310/)