### PR TITLE
Set the return value of rmw_ret_t before entering the loop.

### DIFF
--- a/test_rmw_implementation/test/test_client.cpp
+++ b/test_rmw_implementation/test/test_client.cpp
@@ -385,7 +385,7 @@ TEST_F(CLASSNAME(TestClientUse, RMW_IMPLEMENTATION), service_server_is_available
 TEST_F(CLASSNAME(TestClientUse, RMW_IMPLEMENTATION), service_server_is_available_good_args)
 {
   bool is_available;
-  rmw_ret_t ret;
+  rmw_ret_t ret = RMW_RET_ERROR;
   SLEEP_AND_RETRY_UNTIL(rmw_intraprocess_discovery_delay, rmw_intraprocess_discovery_delay * 10) {
     ret = rmw_service_server_is_available(node, client, &is_available);
     if (RMW_RET_OK == ret && is_available) {


### PR DESCRIPTION
clang static analysis pointed out that if we never did *any*
iterations of the loop in SLEEP_AND_RETRY_UNTIL, then we
would be comparing an uninitialized value of rmw_ret_t with
RMW_RET_OK.  Just set it to RMW_RET_ERROR in this unlikely
case which will cause us to fail the test.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>