### PR TITLE
Make sure to initialize the rmw_message_sequence after init.

### DIFF
--- a/test_rmw_implementation/test/test_subscription.cpp
+++ b/test_rmw_implementation/test/test_subscription.cpp
@@ -24,6 +24,7 @@
 #include "rmw/error_handling.h"
 
 #include "test_msgs/msg/basic_types.h"
+#include "test_msgs/msg/strings.h"
 #include "./config.hpp"
 #include "./testing_macros.hpp"
 
@@ -530,6 +531,12 @@ TEST_F(CLASSNAME(TestSubscriptionUse, RMW_IMPLEMENTATION), take_sequence) {
   rmw_message_sequence_t sequence = rmw_get_zero_initialized_message_sequence();
   rmw_ret_t ret = rmw_message_sequence_init(&sequence, count, &allocator);
   EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+
+  auto seq = test_msgs__msg__Strings__Sequence__create(count);
+  for (size_t ii = 0; ii < count; ++ii) {
+    sequence.data[ii] = &seq->data[ii];
+  }
+
   rmw_message_info_sequence_t info_sequence = rmw_get_zero_initialized_message_info_sequence();
   ret = rmw_message_info_sequence_init(&info_sequence, count, &allocator);
   EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;

--- a/test_rmw_implementation/test/test_subscription.cpp
+++ b/test_rmw_implementation/test/test_subscription.cpp
@@ -546,11 +546,13 @@ TEST_F(CLASSNAME(TestSubscriptionUse, RMW_IMPLEMENTATION), take_sequence) {
   EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
   EXPECT_EQ(taken, 0u);
 
+  ret = rmw_message_info_sequence_fini(&info_sequence);
+  EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+
   ret = rmw_message_sequence_fini(&sequence);
   EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
 
-  ret = rmw_message_info_sequence_fini(&info_sequence);
-  EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+  test_msgs__msg__Strings__Sequence__destroy(seq);
 }
 
 TEST_F(CLASSNAME(TestSubscriptionUse, RMW_IMPLEMENTATION), take_sequence_with_bad_args) {


### PR DESCRIPTION
The documentation for "rmw_take_sequence" says:

"Given `message_sequence` must be a valid message sequence, initialized
by rmw_message_sequence_init() and populated with ROS messages whose
type matches the message type support registered with the `subscription`
on creation."

As it stands, the take_sequence test fulfills the first part of that
(it was initialized by rmw_message_sequence_init()), but doesn't fulfill
the second part (populated by ROS messages).  In certain situations,
this could lead to an aborted test later on.  Make sure to do the
initialization to a known type before calling rmw_take_sequence.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This fixes the test part of the problem in https://github.com/ros2/rmw_cyclonedds/issues/279 .  There is still some follow-up work to do in the RMWs, but that can be done separately.