### PR TITLE
Use new rmw_duration_t

### DIFF
--- a/rmw_implementation/src/functions.cpp
+++ b/rmw_implementation/src/functions.cpp
@@ -493,7 +493,7 @@ RMW_INTERFACE_FN(
   rmw_ret_t, RMW_RET_ERROR,
   7, ARG_TYPES(
     rmw_subscriptions_t *, rmw_guard_conditions_t *, rmw_services_t *, rmw_clients_t *,
-    rmw_events_t *, rmw_wait_set_t *, const rmw_time_t *))
+    rmw_events_t *, rmw_wait_set_t *, rmw_duration_t))
 
 RMW_INTERFACE_FN(
   rmw_get_publisher_names_and_types_by_node,

--- a/test_rmw_implementation/test/test_service.cpp
+++ b/test_rmw_implementation/test/test_service.cpp
@@ -374,13 +374,12 @@ TEST_F(CLASSNAME(TestService, RMW_IMPLEMENTATION), send_reponse_with_bad_argumen
   rmw_services_t srv_array;
   srv_array.service_count = 1u;
   srv_array.services = array;
-  rmw_time_t timeout;
+  rmw_duration_t timeout;
   auto rmw_intraprocess_discovery_delay_in_nanoseconds =
     std::chrono::duration_cast<std::chrono::nanoseconds>(
     rmw_intraprocess_discovery_delay * 10).count();
-  timeout.sec = rmw_intraprocess_discovery_delay_in_nanoseconds / 1000000000;
-  timeout.nsec = rmw_intraprocess_discovery_delay_in_nanoseconds % 1000000000;
-  ret = rmw_wait(nullptr, nullptr, &srv_array, nullptr, nullptr, wait_set, &timeout);
+  timeout = rmw_intraprocess_discovery_delay_in_nanoseconds;
+  ret = rmw_wait(nullptr, nullptr, &srv_array, nullptr, nullptr, wait_set, timeout);
   ASSERT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
   ASSERT_NE(nullptr, srv_array.services[0]);
 
@@ -469,13 +468,12 @@ TEST_F(CLASSNAME(TestService, RMW_IMPLEMENTATION), send_reponse_with_client_gone
   rmw_services_t srv_array;
   srv_array.service_count = 1u;
   srv_array.services = array;
-  rmw_time_t timeout;
+  rmw_duration_t timeout;
   auto rmw_intraprocess_discovery_delay_in_nanoseconds =
     std::chrono::duration_cast<std::chrono::nanoseconds>(
     rmw_intraprocess_discovery_delay * 10).count();
-  timeout.sec = rmw_intraprocess_discovery_delay_in_nanoseconds / 1000000000;
-  timeout.nsec = rmw_intraprocess_discovery_delay_in_nanoseconds % 1000000000;
-  ret = rmw_wait(nullptr, nullptr, &srv_array, nullptr, nullptr, wait_set, &timeout);
+  timeout = rmw_intraprocess_discovery_delay_in_nanoseconds;
+  ret = rmw_wait(nullptr, nullptr, &srv_array, nullptr, nullptr, wait_set, timeout);
   ASSERT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
   ASSERT_NE(nullptr, srv_array.services[0]);
 

--- a/test_rmw_implementation/test/test_wait_set.cpp
+++ b/test_rmw_implementation/test/test_wait_set.cpp
@@ -187,15 +187,15 @@ TEST_F(CLASSNAME(TestWaitSetUse, RMW_IMPLEMENTATION), rmw_wait)
   });
 
   // Call rmw_wait with invalid arguments
-  rmw_ret_t ret = rmw_wait(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+  rmw_ret_t ret = rmw_wait(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, -1);
   EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT) << rcutils_get_error_string().str;
   rmw_reset_error();
 
   // Created two timeout,
   // - Equal to zero: do not block -- check only for immediately available entities.
   // - 100ms: This is represents the maximum amount of time to wait for an entity to become ready.
-  rmw_time_t timeout_argument = {0, 100000000};  // 100ms
-  rmw_time_t timeout_argument_zero = {0, 0};
+  rmw_duration_t timeout_argument = 100000000;  // 100ms
+  rmw_duration_t timeout_argument_zero = 0;
 
   rmw_subscriptions_t subscriptions;
   rmw_guard_conditions_t guard_conditions;
@@ -217,7 +217,7 @@ TEST_F(CLASSNAME(TestWaitSetUse, RMW_IMPLEMENTATION), rmw_wait)
   events.events[0] = &event;
   ret = rmw_wait(
     &subscriptions, &guard_conditions, &services, &clients, &events, wait_set,
-    &timeout_argument);
+    timeout_argument);
   wait_set->implementation_identifier = implementation_identifier;
   EXPECT_EQ(ret, RMW_RET_INCORRECT_RMW_IMPLEMENTATION) << rcutils_get_error_string().str;
   EXPECT_NE(nullptr, subscriptions.subscribers[0]);  // left unchanged
@@ -228,17 +228,17 @@ TEST_F(CLASSNAME(TestWaitSetUse, RMW_IMPLEMENTATION), rmw_wait)
   rmw_reset_error();
 
   // Used a valid wait_set
-  ret = rmw_wait(nullptr, nullptr, nullptr, nullptr, nullptr, wait_set, &timeout_argument);
+  ret = rmw_wait(nullptr, nullptr, nullptr, nullptr, nullptr, wait_set, timeout_argument);
   EXPECT_EQ(ret, RMW_RET_TIMEOUT) << rcutils_get_error_string().str;
   rmw_reset_error();
 
-  ret = rmw_wait(nullptr, nullptr, nullptr, nullptr, nullptr, wait_set, &timeout_argument_zero);
+  ret = rmw_wait(nullptr, nullptr, nullptr, nullptr, nullptr, wait_set, timeout_argument_zero);
   EXPECT_EQ(ret, RMW_RET_TIMEOUT) << rcutils_get_error_string().str;
   rmw_reset_error();
 
   // Used a valid wait_set and subscription with 100ms timeout
   subscriptions.subscribers[0] = sub->data;
-  ret = rmw_wait(&subscriptions, nullptr, nullptr, nullptr, nullptr, wait_set, &timeout_argument);
+  ret = rmw_wait(&subscriptions, nullptr, nullptr, nullptr, nullptr, wait_set, timeout_argument);
   EXPECT_EQ(ret, RMW_RET_TIMEOUT) << rcutils_get_error_string().str;
   EXPECT_EQ(nullptr, subscriptions.subscribers[0]);
   rmw_reset_error();
@@ -247,7 +247,7 @@ TEST_F(CLASSNAME(TestWaitSetUse, RMW_IMPLEMENTATION), rmw_wait)
   subscriptions.subscribers[0] = sub->data;
   ret = rmw_wait(
     &subscriptions, nullptr, nullptr, nullptr, nullptr, wait_set,
-    &timeout_argument_zero);
+    timeout_argument_zero);
   EXPECT_EQ(ret, RMW_RET_TIMEOUT) << rcutils_get_error_string().str;
   EXPECT_EQ(nullptr, subscriptions.subscribers[0]);
   rmw_reset_error();
@@ -257,7 +257,7 @@ TEST_F(CLASSNAME(TestWaitSetUse, RMW_IMPLEMENTATION), rmw_wait)
   guard_conditions.guard_conditions[0] = gc->data;
   ret = rmw_wait(
     &subscriptions, &guard_conditions, nullptr, nullptr, nullptr, wait_set,
-    &timeout_argument);
+    timeout_argument);
   EXPECT_EQ(ret, RMW_RET_TIMEOUT) << rcutils_get_error_string().str;
   EXPECT_EQ(nullptr, subscriptions.subscribers[0]);
   EXPECT_EQ(nullptr, guard_conditions.guard_conditions[0]);
@@ -268,7 +268,7 @@ TEST_F(CLASSNAME(TestWaitSetUse, RMW_IMPLEMENTATION), rmw_wait)
   guard_conditions.guard_conditions[0] = gc->data;
   ret = rmw_wait(
     &subscriptions, &guard_conditions, nullptr, nullptr, nullptr, wait_set,
-    &timeout_argument_zero);
+    timeout_argument_zero);
   EXPECT_EQ(ret, RMW_RET_TIMEOUT) << rcutils_get_error_string().str;
   EXPECT_EQ(nullptr, subscriptions.subscribers[0]);
   EXPECT_EQ(nullptr, guard_conditions.guard_conditions[0]);
@@ -280,7 +280,7 @@ TEST_F(CLASSNAME(TestWaitSetUse, RMW_IMPLEMENTATION), rmw_wait)
   services.services[0] = srv->data;
   ret = rmw_wait(
     &subscriptions, &guard_conditions, &services, nullptr, nullptr, wait_set,
-    &timeout_argument);
+    timeout_argument);
   EXPECT_EQ(ret, RMW_RET_TIMEOUT) << rcutils_get_error_string().str;
   EXPECT_EQ(nullptr, subscriptions.subscribers[0]);
   EXPECT_EQ(nullptr, guard_conditions.guard_conditions[0]);
@@ -293,7 +293,7 @@ TEST_F(CLASSNAME(TestWaitSetUse, RMW_IMPLEMENTATION), rmw_wait)
   services.services[0] = srv->data;
   ret = rmw_wait(
     &subscriptions, &guard_conditions, &services, nullptr, nullptr, wait_set,
-    &timeout_argument_zero);
+    timeout_argument_zero);
   EXPECT_EQ(ret, RMW_RET_TIMEOUT) << rcutils_get_error_string().str;
   EXPECT_EQ(nullptr, subscriptions.subscribers[0]);
   EXPECT_EQ(nullptr, guard_conditions.guard_conditions[0]);
@@ -307,7 +307,7 @@ TEST_F(CLASSNAME(TestWaitSetUse, RMW_IMPLEMENTATION), rmw_wait)
   clients.clients[0] = client->data;
   ret = rmw_wait(
     &subscriptions, &guard_conditions, &services, &clients, nullptr, wait_set,
-    &timeout_argument);
+    timeout_argument);
   EXPECT_EQ(ret, RMW_RET_TIMEOUT) << rcutils_get_error_string().str;
   EXPECT_EQ(nullptr, subscriptions.subscribers[0]);
   EXPECT_EQ(nullptr, guard_conditions.guard_conditions[0]);
@@ -322,7 +322,7 @@ TEST_F(CLASSNAME(TestWaitSetUse, RMW_IMPLEMENTATION), rmw_wait)
   clients.clients[0] = client->data;
   ret = rmw_wait(
     &subscriptions, &guard_conditions, &services, &clients, nullptr, wait_set,
-    &timeout_argument_zero);
+    timeout_argument_zero);
   EXPECT_EQ(ret, RMW_RET_TIMEOUT) << rcutils_get_error_string().str;
   EXPECT_EQ(nullptr, subscriptions.subscribers[0]);
   EXPECT_EQ(nullptr, guard_conditions.guard_conditions[0]);
@@ -339,7 +339,7 @@ TEST_F(CLASSNAME(TestWaitSetUse, RMW_IMPLEMENTATION), rmw_wait)
   events.events[0] = &event;
   ret = rmw_wait(
     &subscriptions, &guard_conditions, &services, &clients, &events, wait_set,
-    &timeout_argument);
+    timeout_argument);
   EXPECT_EQ(ret, RMW_RET_TIMEOUT) << rcutils_get_error_string().str;
   EXPECT_EQ(nullptr, subscriptions.subscribers[0]);
   EXPECT_EQ(nullptr, guard_conditions.guard_conditions[0]);
@@ -357,7 +357,7 @@ TEST_F(CLASSNAME(TestWaitSetUse, RMW_IMPLEMENTATION), rmw_wait)
   events.events[0] = &event;
   ret = rmw_wait(
     &subscriptions, &guard_conditions, &services, &clients, &events, wait_set,
-    &timeout_argument_zero);
+    timeout_argument_zero);
   EXPECT_EQ(ret, RMW_RET_TIMEOUT) << rcutils_get_error_string().str;
   EXPECT_EQ(nullptr, subscriptions.subscribers[0]);
   EXPECT_EQ(nullptr, guard_conditions.guard_conditions[0]);
@@ -376,7 +376,7 @@ TEST_F(CLASSNAME(TestWaitSetUse, RMW_IMPLEMENTATION), rmw_wait)
     events.events[0] = &event;
     ret = rmw_wait(
       &subscriptions, &guard_conditions, &services, &clients, &events, wait_set,
-      &timeout_argument);
+      timeout_argument);
     EXPECT_NE(RMW_RET_OK, ret);
     if (RMW_RET_TIMEOUT == ret) {
       EXPECT_EQ(nullptr, subscriptions.subscribers[0]);


### PR DESCRIPTION
Depends on https://github.com/ros2/rmw/pull/298

Use new rmw_duration_t instead of rmw_time_t for QoS policies and rmw_wait