### PR TITLE
Shorten some excessively long lines of CMake

### DIFF
--- a/rmw_implementation/CMakeLists.txt
+++ b/rmw_implementation/CMakeLists.txt
@@ -83,7 +83,8 @@ else()
 
     find_package(performance_test_fixture REQUIRED)
     # Give cppcheck hints about macro definitions coming from outside this package
-    get_target_property(ament_cmake_cppcheck_ADDITIONAL_INCLUDE_DIRS performance_test_fixture::performance_test_fixture INTERFACE_INCLUDE_DIRECTORIES)
+    get_target_property(ament_cmake_cppcheck_ADDITIONAL_INCLUDE_DIRS performance_test_fixture::performance_test_fixture
+      INTERFACE_INCLUDE_DIRECTORIES)
 
     macro(benchmark_rmws)
       find_package(${rmw_implementation} REQUIRED)


### PR DESCRIPTION
The line length enforcement in ament_lint_cmake has been broken for some time, but will be fixed by ament/ament_lint#236. This change brings this package into compliance with a 120 column limit.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13645)](http://ci.ros2.org/job/ci_linux/13645/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8525)](http://ci.ros2.org/job/ci_linux-aarch64/8525/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11360)](http://ci.ros2.org/job/ci_osx/11360/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13709)](http://ci.ros2.org/job/ci_windows/13709/)