### PR TITLE
Implement test for subscription loaned messages

### DIFF
--- a/test_rmw_implementation/test/test_subscription.cpp
+++ b/test_rmw_implementation/test/test_subscription.cpp
@@ -894,9 +894,26 @@ TEST_F(
 TEST_F(
   CLASSNAME(TestSubscriptionUseLoan, RMW_IMPLEMENTATION),
   rmw_return_loaned_message_from_subscription) {
-  // TODO(lobotuerk): add tests for rmw_return_loaned_message_from_subscription()
-  // when we have an implementation.
-  FAIL() << "Not implemented";
+  test_msgs__msg__BasicTypes msg{};
+  rmw_ret_t ret = rmw_return_loaned_message_from_subscription(nullptr, &msg);
+  EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, ret) << rmw_get_error_string().str;
+  rmw_reset_error();
+
+  ret = rmw_return_loaned_message_from_subscription(sub, nullptr);
+  EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, ret) << rmw_get_error_string().str;
+  rmw_reset_error();
+
+  // Returning a sample that was not loaned
+  ret = rmw_return_loaned_message_from_subscription(sub, &msg);
+  EXPECT_EQ(RMW_RET_ERROR, ret) << rmw_get_error_string().str;
+  rmw_reset_error();
+
+  const char * implementation_identifier = sub->implementation_identifier;
+  sub->implementation_identifier = "not-an-rmw-implementation-identifier";
+  ret = rmw_return_loaned_message_from_subscription(sub, &msg);
+  EXPECT_EQ(RMW_RET_INCORRECT_RMW_IMPLEMENTATION, ret) << rmw_get_error_string().str;
+  rmw_reset_error();
+  sub->implementation_identifier = implementation_identifier;
 }
 
 bool operator==(const test_msgs__msg__BasicTypes & m1, const test_msgs__msg__BasicTypes & m2)

--- a/test_rmw_implementation/test/test_subscription.cpp
+++ b/test_rmw_implementation/test/test_subscription.cpp
@@ -844,9 +844,51 @@ TEST_F(CLASSNAME(TestSubscriptionUseLoan, RMW_IMPLEMENTATION), rmw_take_loaned_m
 
 TEST_F(
   CLASSNAME(TestSubscriptionUseLoan, RMW_IMPLEMENTATION), rmw_take_loaned_message_with_info) {
-  // TODO(lobotuerk): add tests for rmw_take_loaned_message_with_info()
-  // when we have an implementation.
-  FAIL() << "Not implemented";
+  bool taken = false;
+  void * loaned_message = nullptr;
+  rmw_message_info_t message_info = rmw_get_zero_initialized_message_info();
+  rmw_subscription_allocation_t * null_allocation{nullptr};  // still valid allocation
+  rmw_ret_t ret = rmw_take_loaned_message_with_info(
+    nullptr, &loaned_message, &taken, &message_info, null_allocation);
+  EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, ret) << rmw_get_error_string().str;
+  rmw_reset_error();
+  EXPECT_EQ(nullptr, loaned_message);
+  EXPECT_FALSE(taken);
+
+  ret = rmw_take_loaned_message_with_info(
+    sub, nullptr, &taken, &message_info, null_allocation);
+  EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, ret) << rmw_get_error_string().str;
+  rmw_reset_error();
+  EXPECT_EQ(nullptr, loaned_message);
+  EXPECT_FALSE(taken);
+
+  ret = rmw_take_loaned_message_with_info(
+    sub, &loaned_message, nullptr, &message_info, null_allocation);
+  EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, ret) << rmw_get_error_string().str;
+  rmw_reset_error();
+  EXPECT_EQ(nullptr, loaned_message);
+  EXPECT_FALSE(taken);
+
+  ret = rmw_take_loaned_message_with_info(
+    sub, &loaned_message, &taken, nullptr, null_allocation);
+  EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, ret) << rmw_get_error_string().str;
+  rmw_reset_error();
+  EXPECT_EQ(nullptr, loaned_message);
+  EXPECT_FALSE(taken);
+
+  ret = rmw_take_loaned_message_with_info(
+    sub, &loaned_message, &taken, &message_info, null_allocation);
+  EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+  EXPECT_EQ(nullptr, loaned_message);
+  EXPECT_FALSE(taken);
+
+  const char * implementation_identifier = sub->implementation_identifier;
+  sub->implementation_identifier = "not-an-rmw-implementation-identifier";
+  ret = rmw_take_loaned_message_with_info(
+    sub, &loaned_message, &taken, &message_info, null_allocation);
+  EXPECT_EQ(RMW_RET_INCORRECT_RMW_IMPLEMENTATION, ret) << rmw_get_error_string().str;
+  rmw_reset_error();
+  sub->implementation_identifier = implementation_identifier;
 }
 
 TEST_F(

--- a/test_rmw_implementation/test/test_subscription.cpp
+++ b/test_rmw_implementation/test/test_subscription.cpp
@@ -808,8 +808,38 @@ protected:
 };
 
 TEST_F(CLASSNAME(TestSubscriptionUseLoan, RMW_IMPLEMENTATION), rmw_take_loaned_message) {
-  // TODO(lobotuerk): add tests for rmw_take_loaned_message() when we have an implementation.
-  FAIL() << "Not implemented";
+  bool taken = false;
+  void * loaned_message = nullptr;
+  rmw_subscription_allocation_t * null_allocation{nullptr};  // still valid allocation
+  rmw_ret_t ret = rmw_take_loaned_message(nullptr, &loaned_message, &taken, null_allocation);
+  EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, ret) << rmw_get_error_string().str;
+  rmw_reset_error();
+  EXPECT_EQ(nullptr, loaned_message);
+  EXPECT_FALSE(taken);
+
+  ret = rmw_take_loaned_message(sub, nullptr, &taken, null_allocation);
+  EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, ret) << rmw_get_error_string().str;
+  rmw_reset_error();
+  EXPECT_EQ(nullptr, loaned_message);
+  EXPECT_FALSE(taken);
+
+  ret = rmw_take_loaned_message(sub, &loaned_message, nullptr, null_allocation);
+  EXPECT_EQ(RMW_RET_INVALID_ARGUMENT, ret) << rmw_get_error_string().str;
+  rmw_reset_error();
+  EXPECT_EQ(nullptr, loaned_message);
+  EXPECT_FALSE(taken);
+
+  ret = rmw_take_loaned_message(sub, &loaned_message, &taken, null_allocation);
+  EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+  EXPECT_EQ(nullptr, loaned_message);
+  EXPECT_FALSE(taken);
+
+  const char * implementation_identifier = sub->implementation_identifier;
+  sub->implementation_identifier = "not-an-rmw-implementation-identifier";
+  ret = rmw_take_loaned_message(sub, &loaned_message, &taken, null_allocation);
+  EXPECT_EQ(RMW_RET_INCORRECT_RMW_IMPLEMENTATION, ret) << rmw_get_error_string().str;
+  rmw_reset_error();
+  sub->implementation_identifier = implementation_identifier;
 }
 
 TEST_F(


### PR DESCRIPTION
While testing ros2/rmw_fastrtps#523 I discovered [these non-implemented tests](https://github.com/ros2/rmw_implementation/blob/59a549597862659f7fcbaa9f025406a11946ec54/test_rmw_implementation/test/test_subscription.cpp#L810-L828)

This PR provides an implementation for them.