### PR TITLE
Attempt to load any available RMW implementation.

### DIFF
--- a/rmw_implementation/CMakeLists.txt
+++ b/rmw_implementation/CMakeLists.txt
@@ -12,6 +12,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_index_cpp REQUIRED)
 find_package(rmw_implementation_cmake REQUIRED)
 
 if(BUILD_TESTING)
@@ -53,6 +54,7 @@ else()
   add_library(${PROJECT_NAME} SHARED
     src/functions.cpp)
   ament_target_dependencies(${PROJECT_NAME}
+    "ament_index_cpp"
     "rcpputils"
     "rcutils"
     "rmw")
@@ -73,7 +75,7 @@ else()
 
   ament_export_libraries(${PROJECT_NAME})
   ament_export_targets(${PROJECT_NAME})
-  ament_export_dependencies(rcpputils rcutils)
+  ament_export_dependencies(ament_index_cpp rcpputils rcutils)
 
   if(BUILD_TESTING)
     find_package(ament_cmake_gtest REQUIRED)

--- a/rmw_implementation/package.xml
+++ b/rmw_implementation/package.xml
@@ -13,6 +13,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rmw_implementation_cmake</buildtool_depend>
 
+  <depend>ament_index_cpp</depend>
   <depend>rcpputils</depend>
   <depend>rcutils</depend>
   <build_depend>rmw</build_depend>

--- a/rmw_implementation/src/functions.cpp
+++ b/rmw_implementation/src/functions.cpp
@@ -107,15 +107,16 @@ load_library()
 
   // OK, we failed to load the default RMW.  Fetch all of the ones we can
   // find and attempt to load them one-by-one.
+  rmw_reset_error();
   const std::map<std::string, std::string> packages_with_prefixes = ament_index_cpp::get_resources(
     "rmw_typesupport");
   for (const auto & package_prefix_pair : packages_with_prefixes) {
     if (package_prefix_pair.first != "rmw_implementation") {
-      rmw_reset_error();
       ret = attempt_to_load_one_rmw(package_prefix_pair.first);
       if (ret != nullptr) {
         return ret;
       }
+      rmw_reset_error();
     }
   }
 

--- a/rmw_implementation/src/functions.cpp
+++ b/rmw_implementation/src/functions.cpp
@@ -98,8 +98,6 @@ load_library()
   }
 
   // User didn't specify, so next try to load the default RMW
-  rmw_reset_error();
-
   std::shared_ptr<rcpputils::SharedLibrary> ret;
 
   ret = attempt_to_load_one_rmw(STRINGIFY(DEFAULT_RMW_IMPLEMENTATION));

--- a/rmw_implementation/src/functions.cpp
+++ b/rmw_implementation/src/functions.cpp
@@ -15,10 +15,12 @@
 #include "./functions.hpp"
 
 #include <cstddef>
-#include <stdexcept>
-
+#include <map>
 #include <memory>
+#include <stdexcept>
 #include <string>
+
+#include "ament_index_cpp/get_resources.hpp"
 
 #include "rcutils/allocator.h"
 #include "rcutils/format_string.h"
@@ -43,9 +45,43 @@
 
 static std::shared_ptr<rcpputils::SharedLibrary> g_rmw_lib = nullptr;
 
+static std::shared_ptr<rcpputils::SharedLibrary>
+attempt_to_load_one_rmw(const std::string & library)
+{
+  std::string library_name;
+  std::shared_ptr<rcpputils::SharedLibrary> ret = nullptr;
+
+  try {
+    library_name = rcpputils::get_platform_library_name(library);
+  } catch (const std::exception & e) {
+    RMW_SET_ERROR_MSG_WITH_FORMAT_STRING(
+      "failed to compute shared library name due to %s", e.what());
+    return ret;
+  }
+
+  try {
+    ret = std::make_shared<rcpputils::SharedLibrary>(library_name);
+  } catch (const std::exception & e) {
+    RMW_SET_ERROR_MSG_WITH_FORMAT_STRING(
+      "failed to load shared library '%s' due to %s",
+      library_name.c_str(), e.what());
+    ret = nullptr;
+  }
+
+  return ret;
+}
+
 std::shared_ptr<rcpputils::SharedLibrary>
 load_library()
 {
+  // The logic to pick the RMW library to load goes as follows:
+  //
+  // 1. If the user specified the library to use via the RMW_IMPLEMENTATION
+  //    environment variable, try to load only that library.
+  // 2. Otherwise, try to load the default RMW implementation.
+  // 3. If that fails, try loading all other implementations available in turn
+  //    until one succeeds or we run out of options.
+
   std::string env_var;
   try {
     env_var = rcpputils::get_env_var("RMW_IMPLEMENTATION");
@@ -56,27 +92,40 @@ load_library()
     return nullptr;
   }
 
-  if (env_var.empty()) {
-    env_var = STRINGIFY(DEFAULT_RMW_IMPLEMENTATION);
+  // User specified an RMW, attempt to load that one and only that one
+  if (!env_var.empty()) {
+    return attempt_to_load_one_rmw(env_var);
   }
 
-  std::string library_name;
-  try {
-    library_name = rcpputils::get_platform_library_name(env_var);
-  } catch (const std::exception & e) {
-    RMW_SET_ERROR_MSG_WITH_FORMAT_STRING(
-      "failed to compute shared library name due to %s", e.what());
-    return nullptr;
+  // User didn't specify, so next try to load the default RMW
+  rmw_reset_error();
+
+  std::shared_ptr<rcpputils::SharedLibrary> ret;
+
+  ret = attempt_to_load_one_rmw(STRINGIFY(DEFAULT_RMW_IMPLEMENTATION));
+  if (ret != nullptr) {
+    return ret;
   }
 
-  try {
-    return std::make_shared<rcpputils::SharedLibrary>(library_name);
-  } catch (const std::exception & e) {
-    RMW_SET_ERROR_MSG_WITH_FORMAT_STRING(
-      "failed to load shared library '%s' due to %s",
-      library_name.c_str(), e.what());
-    return nullptr;
+  // OK, we failed to load the default RMW.  Fetch all of the ones we can
+  // find and attempt to load them one-by-one.
+  const std::map<std::string, std::string> packages_with_prefixes = ament_index_cpp::get_resources(
+    "rmw_typesupport");
+  for (const auto & package_prefix_pair : packages_with_prefixes) {
+    if (package_prefix_pair.first != "rmw_implementation") {
+      rmw_reset_error();
+      ret = attempt_to_load_one_rmw(package_prefix_pair.first);
+      if (ret != nullptr) {
+        return ret;
+      }
+    }
   }
+
+  // If we made it here, we couldn't find an rmw to load.
+
+  RMW_SET_ERROR_MSG("failed to load any RMW implementations");
+
+  return nullptr;
 }
 
 std::shared_ptr<rcpputils::SharedLibrary>


### PR DESCRIPTION
The old logic was to load what the user asked for (via the
RMW_IMPLEMENTATION environment variable).  If the user didn't
explicitly ask for an implementation, then it would attempt
to load the default RMW implementation.

The new logic is to load what the user asked for.  If the user
didn't explicitly ask for an implementation, attempt to load
the default RMW.  If that fails for some reason, fall back to
loading any available RMW.  If all of that fails, fail the
load.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

One important thing to note about this PR is that it introduces a dependency between `rmw_implementation` and `ament_index_cpp`.  I don't *think* that is a problem, but it bears thinking about.

Besides making the code more robust, this PR should fix problems we are seeing in running demo PR jobs, like https://build.ros2.org/job/Rpr__demos__ubuntu_focal_amd64/131 .

I'm going to run full CI on this; I'm leaving this in draft state until that is done.  Any early feedback is welcome.