### PR TITLE
Remove unused headers

### DIFF
--- a/rmw_implementation/src/functions.cpp
+++ b/rmw_implementation/src/functions.cpp
@@ -22,7 +22,6 @@
 
 #include "rcutils/allocator.h"
 #include "rcutils/format_string.h"
-#include "rcutils/get_env.h"
 #include "rcutils/types/string_array.h"
 
 #include "rcpputils/get_env.hpp"

--- a/rmw_implementation/test/test_functions.cpp
+++ b/rmw_implementation/test/test_functions.cpp
@@ -17,7 +17,6 @@
 #include <memory>
 
 #include "rcutils/env.h"
-#include "rcutils/get_env.h"
 #include "rcutils/testing/fault_injection.h"
 
 #include "rmw/error_handling.h"


### PR DESCRIPTION
https://github.com/ros2/rcutils/pull/340 deprecates `rcutils/get_env.h`. This PR doesn't need to wait until the `rcutils` PR is merged, though.

I simply removed the `#include` since nothing from that header was actually used.