### PR TITLE
Wait for server in test_rmw_implementation service tests

### DIFF
--- a/test_rmw_implementation/test/test_client.cpp
+++ b/test_rmw_implementation/test/test_client.cpp
@@ -386,25 +386,25 @@ TEST_F(CLASSNAME(TestClientUse, RMW_IMPLEMENTATION), service_server_is_available
 {
   bool is_available = false;
   rmw_ret_t ret = rmw_service_server_is_available(node, client, &is_available);
-  EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+  ASSERT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
   ASSERT_FALSE(is_available);
-  rmw_reset_error();
 
   rmw_service_t * service = rmw_create_service(node, ts, service_name, &qos_profile);
-  ASSERT_NE(nullptr, client) << rcutils_get_error_string().str;
+  ASSERT_NE(nullptr, client) << rmw_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    rmw_ret_t ret = rmw_destroy_service(node, service);
+    EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+    rmw_reset_error();
+  });
 
   is_available = false;
   SLEEP_AND_RETRY_UNTIL(rmw_intraprocess_discovery_delay, rmw_intraprocess_discovery_delay * 10) {
     ret = rmw_service_server_is_available(node, client, &is_available);
-    EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
-    rmw_reset_error();
+    ASSERT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
     if (is_available) {
       break;
     }
   }
-  EXPECT_TRUE(is_available) << rmw_get_error_string().str;
-  rmw_reset_error();
-
-  ret = rmw_destroy_service(node, service);
-  EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+  ASSERT_TRUE(is_available);
 }

--- a/test_rmw_implementation/test/test_client.cpp
+++ b/test_rmw_implementation/test/test_client.cpp
@@ -385,26 +385,23 @@ TEST_F(CLASSNAME(TestClientUse, RMW_IMPLEMENTATION), service_server_is_available
 TEST_F(CLASSNAME(TestClientUse, RMW_IMPLEMENTATION), service_server_is_available_good_args)
 {
   bool is_available = false;
-  rmw_ret_t ret = RMW_RET_ERROR;
-  SLEEP_AND_RETRY_UNTIL(rmw_intraprocess_discovery_delay, rmw_intraprocess_discovery_delay * 10) {
-    ret = rmw_service_server_is_available(node, client, &is_available);
-    if (RMW_RET_OK == ret && is_available) {
-      break;
-    }
-  }
-  EXPECT_EQ(ret, RMW_RET_OK) << rmw_get_error_string().str;
-  EXPECT_FALSE(is_available) << rmw_get_error_string().str;
+  rmw_ret_t ret = rmw_service_server_is_available(node, client, &is_available);
+  EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+  ASSERT_FALSE(is_available);
   rmw_reset_error();
 
   rmw_service_t * service = rmw_create_service(node, ts, service_name, &qos_profile);
   ASSERT_NE(nullptr, client) << rcutils_get_error_string().str;
+
+  is_available = false;
   SLEEP_AND_RETRY_UNTIL(rmw_intraprocess_discovery_delay, rmw_intraprocess_discovery_delay * 10) {
     ret = rmw_service_server_is_available(node, client, &is_available);
-    if (RMW_RET_OK == ret && is_available) {
+    EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+    rmw_reset_error();
+    if (is_available) {
       break;
     }
   }
-  EXPECT_EQ(ret, RMW_RET_OK) << rmw_get_error_string().str;
   EXPECT_TRUE(is_available) << rmw_get_error_string().str;
   rmw_reset_error();
 

--- a/test_rmw_implementation/test/test_service.cpp
+++ b/test_rmw_implementation/test/test_service.cpp
@@ -359,13 +359,13 @@ TEST_F(CLASSNAME(TestService, RMW_IMPLEMENTATION), send_reponse_with_bad_argumen
   });
 
   bool is_available = false;
-  for (int i = 0; i < 10; ++i) {
+  SLEEP_AND_RETRY_UNTIL(rmw_intraprocess_discovery_delay, rmw_intraprocess_discovery_delay * 10) {
     rmw_ret_t ret = rmw_service_server_is_available(node, client, &is_available);
     EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+    rmw_reset_error();
     if (is_available) {
       break;
     }
-    std::this_thread::sleep_for(rmw_intraprocess_discovery_delay);
   }
   ASSERT_TRUE(is_available);
 
@@ -465,13 +465,13 @@ TEST_F(CLASSNAME(TestService, RMW_IMPLEMENTATION), send_reponse_with_client_gone
   });
 
   bool is_available = false;
-  for (int i = 0; i < 10; ++i) {
+  SLEEP_AND_RETRY_UNTIL(rmw_intraprocess_discovery_delay, rmw_intraprocess_discovery_delay * 10) {
     rmw_ret_t ret = rmw_service_server_is_available(node, client, &is_available);
     EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+    rmw_reset_error();
     if (is_available) {
       break;
     }
-    std::this_thread::sleep_for(rmw_intraprocess_discovery_delay);
   }
   ASSERT_TRUE(is_available);
 

--- a/test_rmw_implementation/test/test_service.cpp
+++ b/test_rmw_implementation/test/test_service.cpp
@@ -358,6 +358,17 @@ TEST_F(CLASSNAME(TestService, RMW_IMPLEMENTATION), send_reponse_with_bad_argumen
     EXPECT_EQ(RMW_RET_OK, ret) << rcutils_get_error_string().str;
   });
 
+  bool is_available = false;
+  for (int i = 0; i < 10; ++i) {
+    rmw_ret_t ret = rmw_service_server_is_available(node, client, &is_available);
+    EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+    if (is_available) {
+      break;
+    }
+    std::this_thread::sleep_for(rmw_intraprocess_discovery_delay);
+  }
+  ASSERT_TRUE(is_available);
+
   rmw_ret_t ret = rmw_send_request(client, &request, &sequence_number);
   ASSERT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
 
@@ -452,6 +463,17 @@ TEST_F(CLASSNAME(TestService, RMW_IMPLEMENTATION), send_reponse_with_client_gone
       EXPECT_EQ(RMW_RET_OK, ret) << rcutils_get_error_string().str;
     }
   });
+
+  bool is_available = false;
+  for (int i = 0; i < 10; ++i) {
+    rmw_ret_t ret = rmw_service_server_is_available(node, client, &is_available);
+    EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
+    if (is_available) {
+      break;
+    }
+    std::this_thread::sleep_for(rmw_intraprocess_discovery_delay);
+  }
+  ASSERT_TRUE(is_available);
 
   rmw_ret_t ret = rmw_send_request(client, &request, &sequence_number);
   ASSERT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;


### PR DESCRIPTION
Current tests assume service server and client in the same process discover each other immediately. That doesn't seem to be true for `rmw_connextdds` and thus [the flakes in amd64 Linux repeated CI](https://ci.ros2.org/view/nightly/job/nightly_linux_repeated/lastCompletedBuild/testReport/(root)/projectroot/test_service__rmw_connextdds/), which can be reproduced locally (FYI @asorbini). 

This patch amends this. 

Repeated CI up to `test_rmw_implementation`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=14554)](http://ci.ros2.org/job/ci_linux/14554/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=9311)](http://ci.ros2.org/job/ci_linux-aarch64/9311/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=12222)](http://ci.ros2.org/job/ci_osx/12222/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=14681)](http://ci.ros2.org/job/ci_windows/14681/)
