### PR TITLE
Fix rmw_implementation generated documentation

### DIFF
--- a/rmw_implementation/Doxyfile
+++ b/rmw_implementation/Doxyfile
@@ -1,0 +1,13 @@
+# All settings not listed here will use the Doxygen default values.
+
+PROJECT_NAME           = "rmw_implementation"
+PROJECT_NUMBER         = master
+PROJECT_BRIEF          = "Proxy implementation of the ROS 2 Middleware Interface."
+
+INPUT                  = README.md QUALITY_DECLARATION.md
+USE_MDFILE_AS_MAINPAGE = README.md
+OUTPUT_DIRECTORY       = doc_output
+
+SORT_MEMBER_DOCS       = NO
+
+GENERATE_LATEX         = NO

--- a/rmw_implementation/package.xml
+++ b/rmw_implementation/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>rmw_implementation</name>
   <version>2.6.0</version>
-  <description>The decision which ROS middleware implementation should be used for C++.</description>
+  <description>Proxy implementation of the ROS 2 Middleware Interface.</description>
   <maintainer email="alejandro@openrobotics.org">Alejandro Hernandez Cordero</maintainer>
   <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
   <license>Apache License 2.0</license>


### PR DESCRIPTION
Precisely what the title says. Needs https://github.com/ros-infrastructure/rosdoc2/pull/33.