### PR TITLE
Fix linter issues

### DIFF
--- a/test_rmw_implementation/test/test_client.cpp
+++ b/test_rmw_implementation/test/test_client.cpp
@@ -439,7 +439,8 @@ TEST_F(CLASSNAME(TestClient, RMW_IMPLEMENTATION), check_qos) {
   EXPECT_EQ(actual_rp_qos.lifespan.sec, qos_profile.lifespan.sec);
   EXPECT_EQ(actual_rp_qos.lifespan.nsec, qos_profile.lifespan.nsec);
   EXPECT_EQ(actual_rp_qos.liveliness_lease_duration.sec, qos_profile.liveliness_lease_duration.sec);
-  EXPECT_EQ(actual_rp_qos.liveliness_lease_duration.nsec, qos_profile.liveliness_lease_duration.nsec);
+  EXPECT_EQ(
+    actual_rp_qos.liveliness_lease_duration.nsec, qos_profile.liveliness_lease_duration.nsec);
 
   rmw_qos_profile_t actual_rs_qos;
   ret = rmw_client_response_subscription_get_actual_qos(
@@ -455,5 +456,6 @@ TEST_F(CLASSNAME(TestClient, RMW_IMPLEMENTATION), check_qos) {
   EXPECT_EQ(actual_rs_qos.deadline.sec, qos_profile.deadline.sec);
   EXPECT_EQ(actual_rs_qos.deadline.nsec, qos_profile.deadline.nsec);
   EXPECT_EQ(actual_rs_qos.liveliness_lease_duration.sec, qos_profile.liveliness_lease_duration.sec);
-  EXPECT_EQ(actual_rs_qos.liveliness_lease_duration.nsec, qos_profile.liveliness_lease_duration.nsec);
+  EXPECT_EQ(
+    actual_rs_qos.liveliness_lease_duration.nsec, qos_profile.liveliness_lease_duration.nsec);
 }

--- a/test_rmw_implementation/test/test_service.cpp
+++ b/test_rmw_implementation/test/test_service.cpp
@@ -547,7 +547,8 @@ TEST_F(CLASSNAME(TestService, RMW_IMPLEMENTATION), check_qos) {
   EXPECT_EQ(actual_rp_qos.liveliness_lease_duration.sec, qos_profile.liveliness_lease_duration.sec);
   EXPECT_EQ(actual_rp_qos.deadline.nsec, qos_profile.deadline.nsec);
   EXPECT_EQ(actual_rp_qos.lifespan.nsec, qos_profile.lifespan.nsec);
-  EXPECT_EQ(actual_rp_qos.liveliness_lease_duration.nsec, qos_profile.liveliness_lease_duration.nsec);
+  EXPECT_EQ(
+    actual_rp_qos.liveliness_lease_duration.nsec, qos_profile.liveliness_lease_duration.nsec);
 
   rmw_qos_profile_t actual_rs_qos;
   ret = rmw_service_request_subscription_get_actual_qos(
@@ -563,5 +564,6 @@ TEST_F(CLASSNAME(TestService, RMW_IMPLEMENTATION), check_qos) {
   EXPECT_EQ(actual_rs_qos.deadline.sec, qos_profile.deadline.sec);
   EXPECT_EQ(actual_rs_qos.deadline.nsec, qos_profile.deadline.nsec);
   EXPECT_EQ(actual_rs_qos.liveliness_lease_duration.sec, qos_profile.liveliness_lease_duration.sec);
-  EXPECT_EQ(actual_rs_qos.liveliness_lease_duration.nsec, qos_profile.liveliness_lease_duration.nsec);
+  EXPECT_EQ(
+    actual_rs_qos.liveliness_lease_duration.nsec, qos_profile.liveliness_lease_duration.nsec);
 }


### PR DESCRIPTION
Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>

Small PR, should fix linter issues introduced with #196

CI testing `test_rmw_implementation` before PR:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=15646)](http://ci.ros2.org/job/ci_linux/15646/)

CI after PR:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=15647)](http://ci.ros2.org/job/ci_linux/15647/)

(Checking full CI after linux CI passes)