### PR TITLE
Support and prefer exported targets from rmw implementations

### DIFF
--- a/rmw_implementation/CMakeLists.txt
+++ b/rmw_implementation/CMakeLists.txt
@@ -55,10 +55,11 @@ else()
   add_library(${PROJECT_NAME} SHARED
     src/functions.cpp)
   target_link_libraries(${PROJECT_NAME} PUBLIC
+    rmw::rmw)
+  target_link_libraries(${PROJECT_NAME} PRIVATE
     ament_index_cpp::ament_index_cpp
     rcpputils::rcpputils
     rcutils::rcutils
-    rmw::rmw
     Threads::Threads)
   target_compile_definitions(${PROJECT_NAME}
     PUBLIC "DEFAULT_RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION}")

--- a/rmw_implementation/CMakeLists.txt
+++ b/rmw_implementation/CMakeLists.txt
@@ -50,7 +50,6 @@ else()
   find_package(rcpputils REQUIRED)
   find_package(rcutils REQUIRED)
   find_package(rmw REQUIRED)
-  find_package(Threads REQUIRED)
 
   add_library(${PROJECT_NAME} SHARED
     src/functions.cpp)
@@ -59,8 +58,7 @@ else()
   target_link_libraries(${PROJECT_NAME} PRIVATE
     ament_index_cpp::ament_index_cpp
     rcpputils::rcpputils
-    rcutils::rcutils
-    Threads::Threads)
+    rcutils::rcutils)
   target_compile_definitions(${PROJECT_NAME}
     PUBLIC "DEFAULT_RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION}")
 

--- a/rmw_implementation/CMakeLists.txt
+++ b/rmw_implementation/CMakeLists.txt
@@ -50,14 +50,16 @@ else()
   find_package(rcpputils REQUIRED)
   find_package(rcutils REQUIRED)
   find_package(rmw REQUIRED)
+  find_package(Threads REQUIRED)
 
   add_library(${PROJECT_NAME} SHARED
     src/functions.cpp)
-  ament_target_dependencies(${PROJECT_NAME}
-    "ament_index_cpp"
-    "rcpputils"
-    "rcutils"
-    "rmw")
+  target_link_libraries(${PROJECT_NAME} PUBLIC
+    ament_index_cpp::ament_index_cpp
+    rcpputils::rcpputils
+    rcutils::rcutils
+    rmw::rmw
+    Threads::Threads)
   target_compile_definitions(${PROJECT_NAME}
     PUBLIC "DEFAULT_RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION}")
 
@@ -73,8 +75,7 @@ else()
 
   configure_rmw_library(${PROJECT_NAME})
 
-  ament_export_libraries(${PROJECT_NAME})
-  ament_export_targets(${PROJECT_NAME})
+  ament_export_targets(export_${PROJECT_NAME})
   ament_export_dependencies(ament_index_cpp rcpputils rcutils)
 
   if(BUILD_TESTING)
@@ -103,7 +104,7 @@ else()
   endif()
 
   install(
-    TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
+    TARGETS ${PROJECT_NAME} EXPORT export_${PROJECT_NAME}
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION bin

--- a/rmw_implementation/CMakeLists.txt
+++ b/rmw_implementation/CMakeLists.txt
@@ -81,7 +81,11 @@ else()
     find_package(ament_cmake_gtest REQUIRED)
     ament_add_gtest(test_functions test/test_functions.cpp)
     ament_target_dependencies(test_functions rcutils rmw)
-    target_link_libraries(test_functions ${PROJECT_NAME})
+    target_link_libraries(test_functions
+      ${PROJECT_NAME}
+      ament_index_cpp::ament_index_cpp
+      rcpputils::rcpputils
+      rcutils::rcutils)
 
     find_package(performance_test_fixture REQUIRED)
     # Give cppcheck hints about macro definitions coming from outside this package
@@ -96,7 +100,11 @@ else()
       add_performance_test(benchmark_symbols${target_suffix} test/benchmark/benchmark_symbols.cpp
         ENV ${rmw_implementation_env_var})
       if(TARGET benchmark_symbols${target_suffix})
-        target_link_libraries(benchmark_symbols${target_suffix} ${PROJECT_NAME})
+        target_link_libraries(benchmark_symbols${target_suffix}
+          ${PROJECT_NAME}
+          ament_index_cpp::ament_index_cpp
+          rcpputils::rcpputils
+          rcutils::rcutils)
       endif()
     endmacro()
     call_for_each_rmw_implementation(benchmark_rmws)

--- a/rmw_implementation/rmw_implementation-extras.cmake.in
+++ b/rmw_implementation/rmw_implementation-extras.cmake.in
@@ -30,13 +30,29 @@ if(@RMW_IMPLEMENTATION_DISABLE_RUNTIME_SELECTION@)
   endif()
   find_package("@RMW_IMPLEMENTATION@" REQUIRED)
 
-  # TODO should never need definitions and include dirs?
-  list(APPEND rmw_implementation_DEFINITIONS
-    ${@RMW_IMPLEMENTATION@_DEFINITIONS})
-  list(APPEND rmw_implementation_INCLUDE_DIRS
-    ${@RMW_IMPLEMENTATION@_INCLUDE_DIRS})
-  list(APPEND rmw_implementation_LIBRARIES
-    ${@RMW_IMPLEMENTATION@_LIBRARIES})
+  # Create a target rmw_implementation::rmw_implementation that depends on the real implementation
+  add_library(rmw_implementation::rmw_implementation INTERFACE IMPORTED)
+
+  if(DEFINED @RMW_IMPLEMENTATION@_TARGETS)
+    # First preference: depend on all targets exported by the package
+    target_link_libraries(rmw_implementation::rmw_implementation INTERFACE
+      ${@RMW_IMPLEMENTATION@_TARGETS})
+  elseif(TARGET @RMW_IMPLEMENTATION@::@RMW_IMPLEMENTATION@)
+    # Next preference: depend on a target with the package's name
+    target_link_libraries(rmw_implementation::rmw_implementation INTERFACE
+      @RMW_IMPLEMENTATION@::@RMW_IMPLEMENTATION@)
+  else()
+    # Last resort: assume old-style CMake variables are set
+    target_compile_definitions(rmw_implementation::rmw_implementation INTERFACE
+      ${@RMW_IMPLEMENTATION@_DEFINITIONS})
+    target_include_directories(rmw_implementation::rmw_implementation INTERFACE
+      ${@RMW_IMPLEMENTATION@_INCLUDE_DIRS})
+    target_link_libraries(rmw_implementation::rmw_implementation INTERFACE
+      ${@RMW_IMPLEMENTATION@_LIBRARIES})
+  endif()
+
+  list(APPEND rmw_implementation_TARGETS
+    rmw_implementation::rmw_implementation)
 else()
   get_available_rmw_implementations(available_rmw_implementations)
 
@@ -53,6 +69,3 @@ else()
   # no need to find_package @PROJECT_NAME@
   # since this code is already part of a find_package call of that package
 endif()
-
-find_package(Threads REQUIRED)
-list(APPEND rmw_implementation_LIBRARIES "${CMAKE_THREAD_LIBS_INIT}")


### PR DESCRIPTION
@Blast545 FYI this is an attempt to fix the CI issue from ros2/rmw_cyclonedds#357
~Requires ros2/rmw_cyclonedds#360~ :heavy_check_mark: 
~Requires ros2/realtime_support#112~ :heavy_check_mark: 

The package `rmw_implementation` appears to be the CMake interface between downstream libraries like `rcl` and the actual rmw implementations. It looks like when there are multiple rmw_implementations it will export a shared library that can load and switch between them, but when there is only one implementation it sets old-style standard CMake variables to the underlying implementation. Unfortunately, the latter expects the rmw implementation to set old-style CMake variables instead of modern CMake targets.

This PR creates an `IMPORTED` target `rmw_implementation::rmw_implementation` and variable `rmw_implementation_TARGETS` that lets downstream packages like rcl depend on targets instead of old-style CMake variables. It also updates the logic to support, and prefer, modern CMake from the rmw implementations when available.

I also replaced an out-of-place `CMAKE_THREAD_LIBS_INIT`  with a dependency on `Threads::Threads` on the shared library.