### PR TITLE
Fix relative path include syntax for cpplint

### DIFF
--- a/rmw_implementation/src/functions.cpp
+++ b/rmw_implementation/src/functions.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "./functions.hpp"
+#include "functions.hpp"
 
 #include <cstddef>
 #include <map>


### PR DESCRIPTION
Relates to https://github.com/ament/ament_lint/pull/324