### PR TITLE
Runtime Interface Reflection: rmw_implementation

### DIFF
--- a/rmw_implementation/src/functions.cpp
+++ b/rmw_implementation/src/functions.cpp
@@ -769,7 +769,7 @@ RMW_INTERFACE_FN(
 RMW_INTERFACE_FN(
   rmw_get_serialization_support,
   rmw_ret_t, RMW_RET_ERROR,
-  2, ARG_TYPES(const char *, rosidl_dynamic_typesupport_serialization_support_t **))
+  2, ARG_TYPES(const char *, rosidl_dynamic_typesupport_serialization_support_t * *))
 
 
 #define GET_SYMBOL(x) symbol_ ## x = get_symbol(#x);

--- a/rmw_implementation/src/functions.cpp
+++ b/rmw_implementation/src/functions.cpp
@@ -747,6 +747,27 @@ RMW_INTERFACE_FN(
   1, ARG_TYPES(
     rmw_feature_t))
 
+RMW_INTERFACE_FN(
+  rmw_take_dynamic_message_with_info,
+  rmw_ret_t, RMW_RET_ERROR,
+  5, ARG_TYPES(
+    const rmw_subscription_t *,
+    rosidl_dynamic_typesupport_dynamic_data_t *,
+    bool *,
+    rmw_message_info_t *,
+    rmw_subscription_allocation_t *))
+
+RMW_INTERFACE_FN(
+  rmw_get_serialization_support,
+  rosidl_dynamic_typesupport_serialization_support_t *, nullptr,
+  1, ARG_TYPES(const char *))
+
+RMW_INTERFACE_FN(
+  rmw_serialized_to_dynamic_data,
+  rmw_ret_t, RMW_RET_ERROR,
+  2, ARG_TYPES(rmw_serialized_message_t *, rosidl_dynamic_typesupport_dynamic_data_t *))
+
+
 #define GET_SYMBOL(x) symbol_ ## x = get_symbol(#x);
 
 void prefetch_symbols(void)
@@ -840,6 +861,9 @@ void prefetch_symbols(void)
   GET_SYMBOL(rmw_client_set_on_new_response_callback)
   GET_SYMBOL(rmw_event_set_callback)
   GET_SYMBOL(rmw_feature_supported)
+  GET_SYMBOL(rmw_take_dynamic_message_with_info)
+  GET_SYMBOL(rmw_get_serialization_support)
+  GET_SYMBOL(rmw_serialized_to_dynamic_data)
 }
 
 void * symbol_rmw_init = nullptr;
@@ -956,5 +980,8 @@ unload_library()
   symbol_rmw_client_set_on_new_response_callback = nullptr;
   symbol_rmw_event_set_callback = nullptr;
   symbol_rmw_feature_supported = nullptr;
+  symbol_rmw_take_dynamic_message_with_info = nullptr;
+  symbol_rmw_get_serialization_support = nullptr;
+  symbol_rmw_serialized_to_dynamic_data = nullptr;
   g_rmw_lib.reset();
 }

--- a/rmw_implementation/src/functions.cpp
+++ b/rmw_implementation/src/functions.cpp
@@ -762,11 +762,6 @@ RMW_INTERFACE_FN(
   rosidl_dynamic_typesupport_serialization_support_t *, nullptr,
   1, ARG_TYPES(const char *))
 
-RMW_INTERFACE_FN(
-  rmw_serialized_to_dynamic_data,
-  rmw_ret_t, RMW_RET_ERROR,
-  2, ARG_TYPES(rmw_serialized_message_t *, rosidl_dynamic_typesupport_dynamic_data_t *))
-
 
 #define GET_SYMBOL(x) symbol_ ## x = get_symbol(#x);
 
@@ -863,7 +858,6 @@ void prefetch_symbols(void)
   GET_SYMBOL(rmw_feature_supported)
   GET_SYMBOL(rmw_take_dynamic_message_with_info)
   GET_SYMBOL(rmw_get_serialization_support)
-  GET_SYMBOL(rmw_serialized_to_dynamic_data)
 }
 
 void * symbol_rmw_init = nullptr;
@@ -982,6 +976,5 @@ unload_library()
   symbol_rmw_feature_supported = nullptr;
   symbol_rmw_take_dynamic_message_with_info = nullptr;
   symbol_rmw_get_serialization_support = nullptr;
-  symbol_rmw_serialized_to_dynamic_data = nullptr;
   g_rmw_lib.reset();
 }

--- a/rmw_implementation/src/functions.cpp
+++ b/rmw_implementation/src/functions.cpp
@@ -768,8 +768,8 @@ RMW_INTERFACE_FN(
 
 RMW_INTERFACE_FN(
   rmw_get_serialization_support,
-  rosidl_dynamic_typesupport_serialization_support_t *, nullptr,
-  1, ARG_TYPES(const char *))
+  rmw_ret_t, RMW_RET_ERROR,
+  2, ARG_TYPES(const char *, rosidl_dynamic_typesupport_serialization_support_t **))
 
 
 #define GET_SYMBOL(x) symbol_ ## x = get_symbol(#x);

--- a/rmw_implementation/src/functions.cpp
+++ b/rmw_implementation/src/functions.cpp
@@ -748,6 +748,15 @@ RMW_INTERFACE_FN(
     rmw_feature_t))
 
 RMW_INTERFACE_FN(
+  rmw_take_dynamic_message,
+  rmw_ret_t, RMW_RET_ERROR,
+  4, ARG_TYPES(
+    const rmw_subscription_t *,
+    rosidl_dynamic_typesupport_dynamic_data_t *,
+    bool *,
+    rmw_subscription_allocation_t *))
+
+RMW_INTERFACE_FN(
   rmw_take_dynamic_message_with_info,
   rmw_ret_t, RMW_RET_ERROR,
   5, ARG_TYPES(
@@ -856,6 +865,7 @@ void prefetch_symbols(void)
   GET_SYMBOL(rmw_client_set_on_new_response_callback)
   GET_SYMBOL(rmw_event_set_callback)
   GET_SYMBOL(rmw_feature_supported)
+  GET_SYMBOL(rmw_take_dynamic_message)
   GET_SYMBOL(rmw_take_dynamic_message_with_info)
   GET_SYMBOL(rmw_get_serialization_support)
 }
@@ -974,6 +984,7 @@ unload_library()
   symbol_rmw_client_set_on_new_response_callback = nullptr;
   symbol_rmw_event_set_callback = nullptr;
   symbol_rmw_feature_supported = nullptr;
+  symbol_rmw_take_dynamic_message = nullptr;
   symbol_rmw_take_dynamic_message_with_info = nullptr;
   symbol_rmw_get_serialization_support = nullptr;
   g_rmw_lib.reset();


### PR DESCRIPTION
This PR is part of the runtime interface reflection subscription feature of REP-2011: https://github.com/ros2/ros2/issues/1374

# Description
This PR specifies linking/symbol finding for the new rmw methods defined in other PRs in #1374