### PR TITLE
Switch to using target_link_libraries everywhere.

### DIFF
--- a/rmw_implementation/CMakeLists.txt
+++ b/rmw_implementation/CMakeLists.txt
@@ -81,12 +81,12 @@ else()
   if(BUILD_TESTING)
     find_package(ament_cmake_gtest REQUIRED)
     ament_add_gtest(test_functions test/test_functions.cpp)
-    ament_target_dependencies(test_functions rcutils rmw)
     target_link_libraries(test_functions
       ${PROJECT_NAME}
-      ament_index_cpp::ament_index_cpp
       rcpputils::rcpputils
-      rcutils::rcutils)
+      rcutils::rcutils
+      rmw::rmw
+    )
 
     find_package(performance_test_fixture REQUIRED)
     # Give cppcheck hints about macro definitions coming from outside this package

--- a/test_rmw_implementation/CMakeLists.txt
+++ b/test_rmw_implementation/CMakeLists.txt
@@ -20,10 +20,11 @@ if(BUILD_TESTING)
 
   find_package(rcutils REQUIRED)
   find_package(rmw REQUIRED)
+  find_package(rmw_dds_common REQUIRED)
   find_package(rmw_implementation REQUIRED)
   find_package(rmw_implementation_cmake REQUIRED)
+  find_package(rosidl_runtime_c REQUIRED)
   find_package(test_msgs REQUIRED)
-  find_package(rmw_dds_common REQUIRED)
 
   macro(test_api)
     find_package(${rmw_implementation} REQUIRED)
@@ -36,8 +37,11 @@ if(BUILD_TESTING)
     )
     target_compile_definitions(test_init_shutdown${target_suffix}
       PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
-    ament_target_dependencies(test_init_shutdown${target_suffix}
-      osrf_testing_tools_cpp rcutils rmw rmw_implementation
+    target_link_libraries(test_init_shutdown${target_suffix}
+      osrf_testing_tools_cpp::memory_tools
+      rcutils::rcutils
+      rmw::rmw
+      rmw_implementation::rmw_implementation
     )
 
     ament_add_gtest(test_init_options${target_suffix}
@@ -46,8 +50,11 @@ if(BUILD_TESTING)
     )
     target_compile_definitions(test_init_options${target_suffix}
       PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
-    ament_target_dependencies(test_init_options${target_suffix}
-      osrf_testing_tools_cpp rcutils rmw rmw_implementation
+    target_link_libraries(test_init_options${target_suffix}
+      osrf_testing_tools_cpp::memory_tools
+      rcutils::rcutils
+      rmw::rmw
+      rmw_implementation::rmw_implementation
     )
 
     ament_add_gtest(test_create_destroy_node${target_suffix}
@@ -56,8 +63,11 @@ if(BUILD_TESTING)
     )
     target_compile_definitions(test_create_destroy_node${target_suffix}
       PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
-    ament_target_dependencies(test_create_destroy_node${target_suffix}
-      osrf_testing_tools_cpp rcutils rmw rmw_implementation
+    target_link_libraries(test_create_destroy_node${target_suffix}
+      osrf_testing_tools_cpp::memory_tools
+      rcutils::rcutils
+      rmw::rmw
+      rmw_implementation::rmw_implementation
     )
 
     ament_add_gtest(test_publisher${target_suffix}
@@ -66,8 +76,12 @@ if(BUILD_TESTING)
     )
     target_compile_definitions(test_publisher${target_suffix}
       PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
-    ament_target_dependencies(test_publisher${target_suffix}
-      osrf_testing_tools_cpp rcutils rmw rmw_implementation test_msgs
+    target_link_libraries(test_publisher${target_suffix}
+      osrf_testing_tools_cpp::memory_tools
+      rcutils::rcutils
+      rmw::rmw
+      rmw_implementation::rmw_implementation
+      ${test_msgs_TARGETS}
     )
 
     ament_add_gtest(test_subscription${target_suffix}
@@ -77,8 +91,13 @@ if(BUILD_TESTING)
     )
     target_compile_definitions(test_subscription${target_suffix}
       PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
-    ament_target_dependencies(test_subscription${target_suffix}
-      osrf_testing_tools_cpp rcutils rmw rmw_implementation test_msgs rmw_dds_common
+    target_link_libraries(test_subscription${target_suffix}
+      osrf_testing_tools_cpp::memory_tools
+      rcutils::rcutils
+      rmw::rmw
+      rmw_dds_common::rmw_dds_common_library
+      rmw_implementation::rmw_implementation
+      ${test_msgs_TARGETS}
     )
 
     ament_add_gtest(test_serialize_deserialize${target_suffix}
@@ -87,8 +106,13 @@ if(BUILD_TESTING)
     )
     target_compile_definitions(test_serialize_deserialize${target_suffix}
       PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
-    ament_target_dependencies(test_serialize_deserialize${target_suffix}
-      osrf_testing_tools_cpp rcutils rmw rmw_implementation test_msgs
+    target_link_libraries(test_serialize_deserialize${target_suffix}
+      osrf_testing_tools_cpp::memory_tools
+      rcutils::rcutils
+      rosidl_runtime_c::rosidl_runtime_c
+      rmw::rmw
+      rmw_implementation::rmw_implementation
+      ${test_msgs_TARGETS}
     )
 
     ament_add_gtest(test_publisher_allocator${target_suffix}
@@ -97,17 +121,20 @@ if(BUILD_TESTING)
     )
     target_compile_definitions(test_publisher_allocator${target_suffix}
       PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
-    ament_target_dependencies(test_publisher_allocator${target_suffix}
-      rmw rmw_implementation
+    target_link_libraries(test_publisher_allocator${target_suffix}
+      rmw::rmw
+      rmw_implementation::rmw_implementation
     )
+
     ament_add_gtest(test_subscription_allocator${target_suffix}
       test/test_subscription_allocator.cpp
       ENV ${rmw_implementation_env_var}
     )
     target_compile_definitions(test_subscription_allocator${target_suffix}
       PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
-    ament_target_dependencies(test_subscription_allocator${target_suffix}
-      rmw rmw_implementation
+    target_link_libraries(test_subscription_allocator${target_suffix}
+      rmw::rmw
+      rmw_implementation::rmw_implementation
     )
 
     ament_add_gtest(test_wait_set${target_suffix}
@@ -116,8 +143,12 @@ if(BUILD_TESTING)
     )
     target_compile_definitions(test_wait_set${target_suffix}
       PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
-    ament_target_dependencies(test_wait_set${target_suffix}
-      rmw rmw_implementation rcutils osrf_testing_tools_cpp test_msgs
+    target_link_libraries(test_wait_set${target_suffix}
+      osrf_testing_tools_cpp::memory_tools
+      rcutils::rcutils
+      rmw::rmw
+      rmw_implementation::rmw_implementation
+      ${test_msgs_TARGETS}
     )
 
     ament_add_gtest(test_graph_api${target_suffix}
@@ -127,8 +158,12 @@ if(BUILD_TESTING)
     )
     target_compile_definitions(test_graph_api${target_suffix}
       PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
-    ament_target_dependencies(test_graph_api${target_suffix}
-      osrf_testing_tools_cpp rcutils rmw rmw_implementation test_msgs
+    target_link_libraries(test_graph_api${target_suffix}
+      osrf_testing_tools_cpp::memory_tools
+      rcutils::rcutils
+      rmw::rmw
+      rmw_implementation::rmw_implementation
+      ${test_msgs_TARGETS}
     )
 
     ament_add_gtest(test_unique_identifiers${target_suffix}
@@ -137,8 +172,12 @@ if(BUILD_TESTING)
     )
     target_compile_definitions(test_unique_identifiers${target_suffix}
       PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
-    ament_target_dependencies(test_unique_identifiers${target_suffix}
-      osrf_testing_tools_cpp rcutils rmw rmw_implementation test_msgs
+    target_link_libraries(test_unique_identifiers${target_suffix}
+      osrf_testing_tools_cpp::memory_tools
+      rcutils::rcutils
+      rmw::rmw
+      rmw_implementation::rmw_implementation
+      ${test_msgs_TARGETS}
     )
 
     ament_add_gtest(test_service${target_suffix}
@@ -147,8 +186,12 @@ if(BUILD_TESTING)
     )
     target_compile_definitions(test_service${target_suffix}
       PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
-    ament_target_dependencies(test_service${target_suffix}
-      osrf_testing_tools_cpp rcutils rmw rmw_implementation test_msgs
+    target_link_libraries(test_service${target_suffix}
+      osrf_testing_tools_cpp::memory_tools
+      rcutils::rcutils
+      rmw::rmw
+      rmw_implementation::rmw_implementation
+      ${test_msgs_TARGETS}
     )
 
     ament_add_gtest(test_client${target_suffix}
@@ -158,8 +201,12 @@ if(BUILD_TESTING)
     )
     target_compile_definitions(test_client${target_suffix}
       PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
-    ament_target_dependencies(test_client${target_suffix}
-      osrf_testing_tools_cpp rcutils rmw rmw_implementation test_msgs
+    target_link_libraries(test_client${target_suffix}
+      osrf_testing_tools_cpp::memory_tools
+      rcutils::rcutils
+      rmw::rmw
+      rmw_implementation::rmw_implementation
+      ${test_msgs_TARGETS}
     )
 
     ament_add_gtest(test_qos_profile_check_compatible${target_suffix}
@@ -168,8 +215,9 @@ if(BUILD_TESTING)
     )
     target_compile_definitions(test_qos_profile_check_compatible${target_suffix}
       PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
-    ament_target_dependencies(test_qos_profile_check_compatible${target_suffix}
-      rmw rmw_implementation
+    target_link_libraries(test_qos_profile_check_compatible${target_suffix}
+      rmw::rmw
+      rmw_implementation::rmw_implementation
     )
 
     ament_add_gtest(test_duration_infinite${target_suffix}
@@ -178,18 +226,25 @@ if(BUILD_TESTING)
     )
     target_compile_definitions(test_duration_infinite${target_suffix}
       PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
-    ament_target_dependencies(test_duration_infinite${target_suffix}
-      osrf_testing_tools_cpp rcutils rmw rmw_implementation test_msgs
+    target_link_libraries(test_duration_infinite${target_suffix}
+      osrf_testing_tools_cpp::memory_tools
+      rcutils::rcutils
+      rmw::rmw
+      rmw_implementation::rmw_implementation
+      ${test_msgs_TARGETS}
     )
 
     ament_add_gtest(test_event${target_suffix}
-    test/test_event.cpp
-    ENV ${rmw_implementation_env_var}
+      test/test_event.cpp
+      ENV ${rmw_implementation_env_var}
     )
     target_compile_definitions(test_event${target_suffix}
       PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
-    ament_target_dependencies(test_event${target_suffix}
-      osrf_testing_tools_cpp rmw rmw_implementation test_msgs
+    target_link_libraries(test_event${target_suffix}
+      osrf_testing_tools_cpp::memory_tools
+      rmw::rmw
+      rmw_implementation::rmw_implementation
+      ${test_msgs_TARGETS}
     )
   endmacro()
 

--- a/test_rmw_implementation/package.xml
+++ b/test_rmw_implementation/package.xml
@@ -23,6 +23,7 @@
   <test_depend>rmw_implementation</test_depend>
   <test_depend>rmw_dds_common</test_depend>
   <test_depend>rmw_implementation_cmake</test_depend>
+  <test_depend>rosidl_runtime_c</test_depend>
   <test_depend>test_msgs</test_depend>
 
   <export>


### PR DESCRIPTION
There is just no need to use ament_target_dependencies here.