### PR TITLE
Add mechanism to disable workaround for dependency groups

### DIFF
--- a/rmw_implementation/package.xml
+++ b/rmw_implementation/package.xml
@@ -21,15 +21,12 @@
   <depend>rcpputils</depend>
   <depend>rcutils</depend>
   <build_depend>rmw</build_depend>
-  <!--
-  Bloom does not support group_depend so entries below duplicate the group rmw_implementation_packages.
-  This ensures that binary packages have support for all of these rmw impl. enabled.
-  -->
-  <build_depend>rmw_connextdds</build_depend>
-  <build_depend>rmw_cyclonedds_cpp</build_depend>
-  <build_depend>rmw_fastrtps_cpp</build_depend>
-  <build_depend>rmw_fastrtps_dynamic_cpp</build_depend>
-  <!-- end of group dependencies added for bloom -->
+
+  <!-- Explicit group resolution - see ros-infrastructure/catkin_pkg#369 -->
+  <build_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rmw_connextdds</build_depend>
+  <build_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rmw_cyclonedds_cpp</build_depend>
+  <build_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rmw_fastrtps_cpp</build_depend>
+  <build_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rmw_fastrtps_dynamic_cpp</build_depend>
 
   <depend>rmw_implementation_cmake</depend>
 


### PR DESCRIPTION
See ros-infrastructure/catkin_pkg#369

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=20943)](http://ci.ros2.org/job/ci_linux/20943/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=15234)](http://ci.ros2.org/job/ci_linux-aarch64/15234/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=21617)](http://ci.ros2.org/job/ci_windows/21617/)