### PR TITLE
Expect rmw_service_server_is_available to ret RMW_RET_INVALID_ARGUMENT

### DIFF
--- a/test_rmw_implementation/test/test_client.cpp
+++ b/test_rmw_implementation/test/test_client.cpp
@@ -353,15 +353,15 @@ TEST_F(TestClientUse, service_server_is_available_bad_args)
 {
   bool is_available;
   rmw_ret_t ret = rmw_service_server_is_available(nullptr, client, &is_available);
-  EXPECT_EQ(ret, RMW_RET_ERROR) << rmw_get_error_string().str;
+  EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT) << rmw_get_error_string().str;
   rmw_reset_error();
 
   ret = rmw_service_server_is_available(node, nullptr, &is_available);
-  EXPECT_EQ(ret, RMW_RET_ERROR) << rmw_get_error_string().str;
+  EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT) << rmw_get_error_string().str;
   rmw_reset_error();
 
   ret = rmw_service_server_is_available(node, client, nullptr);
-  EXPECT_EQ(ret, RMW_RET_ERROR) << rmw_get_error_string().str;
+  EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT) << rmw_get_error_string().str;
   rmw_reset_error();
 
   const char * implementation_identifier = client->implementation_identifier;


### PR DESCRIPTION
https://github.com/ros2/rmw/pull/277 changed the `rmw_service_server_is_available()` API documentation to indicate that it returns `RMW_RET_INVALID_ARGUMENT` if `node`, `client`, or `is_available` are `NULL`. However, this wasn't the case in practice in the implementations of `rmw_service_server_is_available()` or in the relevant test.

Change the test here to expect `RMW_RET_INVALID_ARGUMENT`.

Required `rmw` implementation PRs:

* https://github.com/ros2/rmw_cyclonedds/pull/496
* https://github.com/ros2/rmw_fastrtps/pull/763
* https://github.com/ros2/rmw_connextdds/pull/150
* (`rmw_zenoh` already returns `RMW_RET_INVALID_ARGUMENT` in this case)