### PR TITLE
Expect rmw_destroy_wait_set to ret RMW_RET_INVALID_ARGUMENT

### DIFF
--- a/test_rmw_implementation/test/test_wait_set.cpp
+++ b/test_rmw_implementation/test/test_wait_set.cpp
@@ -384,7 +384,7 @@ TEST_F(TestWaitSet, rmw_destroy_wait_set)
 {
   // Try to destroy a nullptr
   rmw_ret_t ret = rmw_destroy_wait_set(nullptr);
-  EXPECT_EQ(ret, RMW_RET_ERROR) << rcutils_get_error_string().str;
+  EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT) << rcutils_get_error_string().str;
   rmw_reset_error();
 
   // Created a valid wait set


### PR DESCRIPTION
https://github.com/ros2/rmw/pull/275 changed the `rmw_destroy_wait_set()` API documentation to indicate that it returns `RMW_RET_INVALID_ARGUMENT` if `wait_set` is `NULL`. However, this wasn't the case in practice in the implementations of `rmw_destroy_wait_set()` or in the relevant test.

Change the test here to expect `RMW_RET_INVALID_ARGUMENT`.

Required `rmw` implementation PRs:

* https://github.com/ros2/rmw_cyclonedds/pull/498
* https://github.com/ros2/rmw_fastrtps/pull/766
* https://github.com/ros2/rmw_connextdds/pull/152
* (`rmw_zenoh` already returns `RMW_RET_INVALID_ARGUMENT` in this case)