### PR TITLE
Do not deref msg ptr for rmw_{publish,return}_loaned_message*()

### DIFF
--- a/test_rmw_implementation/test/test_publisher.cpp
+++ b/test_rmw_implementation/test/test_publisher.cpp
@@ -537,11 +537,11 @@ protected:
       EXPECT_EQ(RMW_RET_UNSUPPORTED, ret) << rmw_get_error_string().str;
       rmw_reset_error();
       EXPECT_EQ(nullptr, msg_pointer);
-      ret = rmw_return_loaned_message_from_publisher(pub, &msg_pointer);
+      ret = rmw_return_loaned_message_from_publisher(pub, msg_pointer);
       EXPECT_EQ(RMW_RET_UNSUPPORTED, ret) << rmw_get_error_string().str;
       rmw_reset_error();
       EXPECT_EQ(nullptr, msg_pointer);
-      ret = rmw_publish_loaned_message(pub, &msg_pointer, null_allocation);
+      ret = rmw_publish_loaned_message(pub, msg_pointer, null_allocation);
       EXPECT_EQ(RMW_RET_UNSUPPORTED, ret) << rmw_get_error_string().str;
       rmw_reset_error();
       EXPECT_EQ(nullptr, msg_pointer);


### PR DESCRIPTION
[`rmw_return_loaned_message_from_publisher()`](https://github.com/ros2/rmw/blob/ac4f9afccca3dc305f2b519fdb0fb9131250f2a5/rmw/include/rmw/rmw.h#L483) and [`rmw_publish_loaned_message()`](https://github.com/ros2/rmw/blob/ac4f9afccca3dc305f2b519fdb0fb9131250f2a5/rmw/include/rmw/rmw.h#L621) accept a `void *`, not a `void **`.

It built fine, but probably failed at runtime. I guess none of the `rmw`s currently exercise this part of the test.