### PR TITLE
Fix up some overwritten errors.

### DIFF
--- a/test_rmw_implementation/test/test_publisher_allocator.cpp
+++ b/test_rmw_implementation/test/test_publisher_allocator.cpp
@@ -11,17 +11,21 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #include <gtest/gtest.h>
 
+#include "rmw/error_handling.h"
 #include "rmw/rmw.h"
 
 TEST(TestPublisherAllocator, init_fini_publisher_allocation)
 {
-  if (rmw_init_publisher_allocation(nullptr, nullptr, nullptr) != RMW_RET_UNSUPPORTED) {
-    // Add tests here when the implementation it's supported
+  rmw_ret_t ret = rmw_init_publisher_allocation(nullptr, nullptr, nullptr);
+  rmw_reset_error();
+  if (ret == RMW_RET_UNSUPPORTED) {
     GTEST_SKIP();
-  } else {
-    rmw_ret_t ret = rmw_fini_publisher_allocation(nullptr);
-    EXPECT_EQ(ret, RMW_RET_UNSUPPORTED);
   }
+
+  ASSERT_NE(ret, RMW_RET_UNSUPPORTED);
+
+  // TODO(anyone): Add tests here when the API has been implemented
 }

--- a/test_rmw_implementation/test/test_qos_profile_check_compatible.cpp
+++ b/test_rmw_implementation/test/test_qos_profile_check_compatible.cpp
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 
+#include "rmw/error_handling.h"
 #include "rmw/qos_profiles.h"
 
 TEST(TestQoSProfilesAreCompatible, compatible) {
@@ -43,6 +44,7 @@ TEST(TestQoSProfilesAreCompatible, invalid_input) {
     rmw_ret_t ret = rmw_qos_profile_check_compatible(
       rmw_qos_profile_sensor_data, rmw_qos_profile_sensor_data, nullptr, nullptr, 0u);
     EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
+    rmw_reset_error();
   }
   // Error on null reason and non-zero size
   {
@@ -50,5 +52,6 @@ TEST(TestQoSProfilesAreCompatible, invalid_input) {
     rmw_ret_t ret = rmw_qos_profile_check_compatible(
       rmw_qos_profile_sensor_data, rmw_qos_profile_sensor_data, &compatible, nullptr, 1u);
     EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
+    rmw_reset_error();
   }
 }

--- a/test_rmw_implementation/test/test_serialize_deserialize.cpp
+++ b/test_rmw_implementation/test/test_serialize_deserialize.cpp
@@ -246,8 +246,13 @@ TEST(TestSerializeDeserialize, clean_round_trip_for_cpp_bounded_message) {
 
 TEST(TestSerializeDeserialize, rmw_get_serialized_message_size)
 {
-  if (rmw_get_serialized_message_size(nullptr, nullptr, nullptr) != RMW_RET_UNSUPPORTED) {
-    // TODO(anyone): Add tests here when the implementation it's supported
+  rmw_ret_t ret = rmw_get_serialized_message_size(nullptr, nullptr, nullptr);
+  rmw_reset_error();
+  if (ret == RMW_RET_UNSUPPORTED) {
     GTEST_SKIP();
   }
+
+  ASSERT_NE(ret, RMW_RET_UNSUPPORTED);
+
+  // TODO(anyone): Add tests here when the API has been implemented
 }

--- a/test_rmw_implementation/test/test_subscription_allocator.cpp
+++ b/test_rmw_implementation/test/test_subscription_allocator.cpp
@@ -11,17 +11,21 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #include <gtest/gtest.h>
 
+#include "rmw/error_handling.h"
 #include "rmw/rmw.h"
 
 TEST(TestSubscriptionAllocator, init_fini_subscription_allocation)
 {
-  if (rmw_init_subscription_allocation(nullptr, nullptr, nullptr) != RMW_RET_UNSUPPORTED) {
-    // Add tests here when the implementation it's supported
+  rmw_ret_t ret = rmw_init_subscription_allocation(nullptr, nullptr, nullptr);
+  rmw_reset_error();
+  if (ret == RMW_RET_UNSUPPORTED) {
     GTEST_SKIP();
-  } else {
-    rmw_ret_t ret = rmw_fini_subscription_allocation(nullptr);
-    EXPECT_EQ(ret, RMW_RET_UNSUPPORTED);
   }
+
+  ASSERT_NE(ret, RMW_RET_UNSUPPORTED);
+
+  // TODO(anyone): Add tests here when the API has been implemented
 }


### PR DESCRIPTION
That is, make sure to clear out errors where we should. We also slightly rewrite some of the testing around unsupported APIs, so that they make more sense.