### PR TITLE
Update expectations of tests to remain compatible with non-DDS middlewares

### DIFF
--- a/test_rmw_implementation/test/test_publisher.cpp
+++ b/test_rmw_implementation/test/test_publisher.cpp
@@ -398,6 +398,14 @@ TEST_F(TestPublisherUse, count_mismatched_subscriptions) {
     rmw_create_subscription(node, ts, topic_name, &other_qos_profile, &options);
   ASSERT_NE(nullptr, sub) << rmw_get_error_string().str;
 
+  // For DDS-based middlewares, the QoS defined above might result in a mismatch while it might not
+  // for other middlewares. Hence, we rely on rmw_qos_profile_check_compatible to infer whether
+  // the publisher and subscription will match and accordingly evaluate match counts.
+  rmw_qos_compatibility_type_t compat;
+  rmw_ret_t rmw_ret =
+    rmw_qos_profile_check_compatible(qos_profile, other_qos_profile, &compat, nullptr, 0);
+  ASSERT_EQ(rmw_ret, RMW_RET_OK);
+
   // TODO(hidmic): revisit when https://github.com/ros2/rmw/issues/264 is resolved.
   SLEEP_AND_RETRY_UNTIL(rmw_intraprocess_discovery_delay, rmw_intraprocess_discovery_delay * 10) {
     ret = rmw_publisher_count_matched_subscriptions(pub, &subscription_count);
@@ -410,7 +418,11 @@ TEST_F(TestPublisherUse, count_mismatched_subscriptions) {
     ret = rmw_publisher_count_matched_subscriptions(pub, &subscription_count);
   });
   EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
-  EXPECT_EQ(0u, subscription_count);
+  if (compat == RMW_QOS_COMPATIBILITY_OK) {
+    EXPECT_EQ(1u, subscription_count);
+  } else {
+    EXPECT_EQ(0u, subscription_count);
+  }
 
   ret = rmw_destroy_subscription(node, sub);
   EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;

--- a/test_rmw_implementation/test/test_wait_set.cpp
+++ b/test_rmw_implementation/test/test_wait_set.cpp
@@ -117,7 +117,14 @@ protected:
     ASSERT_NE(nullptr, srv) << rmw_get_error_string().str;
     client = rmw_create_client(node, service_ts, service_name, &rmw_qos_profile_default);
     ASSERT_NE(nullptr, client) << rmw_get_error_string().str;
-    rmw_ret_t ret = rmw_subscription_event_init(&event, sub, RMW_EVENT_LIVELINESS_CHANGED);
+    rmw_ret_t ret = RMW_RET_OK;
+    // rmw_zenoh does not support RMW_EVENT_LIVELINESS_CHANGED.
+    // TODO(Yadunund): Rely on API suggested in https://github.com/ros2/rmw/issues/394 instead.
+    if (std::string(rmw_get_implementation_identifier()).find("rmw_zenoh_cpp") == 0) {
+      ret = rmw_subscription_event_init(&event, sub, RMW_EVENT_PUBLICATION_MATCHED);
+    } else {
+      ret = rmw_subscription_event_init(&event, sub, RMW_EVENT_LIVELINESS_CHANGED);
+    }
     ASSERT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
   }
 


### PR DESCRIPTION
Namely fix expectations such that the tests are compatible with `rmw_zenoh`. Addresses https://github.com/ros2/rmw_zenoh/issues/481