### PR TITLE
Explain rosidl_typesupport_{c,cpp} in rmw impl typesupport list

### DIFF
--- a/rmw_implementation/CMakeLists.txt
+++ b/rmw_implementation/CMakeLists.txt
@@ -121,8 +121,8 @@ else()
 endif()
 
 register_rmw_implementation(
-  "c:rosidl_typesupport_c"
-  "cpp:rosidl_typesupport_cpp"
+  "c"
+  "cpp"
 )
 
 ament_package(

--- a/rmw_implementation/CMakeLists.txt
+++ b/rmw_implementation/CMakeLists.txt
@@ -120,9 +120,13 @@ else()
   )
 endif()
 
+# Listing rosidl_typesupport_{c,cpp} here doesn't make sense, since they're just base language
+# typesupport packages. However, rclpy doesn't get built if C typesupport doesn't exist. It uses
+# get_rmw_typesupport() to get the C typesupport packages for rmw_implementation, which doesn't
+# differentiate between an empty list and no list, so we need to provide at least one package here.
 register_rmw_implementation(
-  "c"
-  "cpp"
+  "c:rosidl_typesupport_c"
+  "cpp:rosidl_typesupport_cpp"
 )
 
 ament_package(


### PR DESCRIPTION
## Description

Part of https://github.com/ros2/rmw/issues/403

Add a comment here to explain why `rosidl_typesupport_{c,cpp}` are listed.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

This is a weird case, because it is not a _real_ `rmw` implementation, yet it still registers as one with `register_rmw_implementation()`. Listing `rosidl_typesupport_{c,cpp}` doesn't make sense. See: https://github.com/ros2/rmw/issues/403#issuecomment-3189083694. **However, it is still necessary**: https://github.com/ros2/rmw/issues/403#issuecomment-3192022849.

`rclpy` doesn't get built if it doesn't find C typesupport for `rmw_implementation`: https://github.com/ros2/rclpy/blob/f3a326cdb92f1a7c9ff23e4911df5ca5ab36822d/rclpy/CMakeLists.txt#L59-L64

It uses `get_rmw_typesupport()` to get the C typesupport packages for `rmw_implementation`. Unfortunately, `get_rmw_typesupport()` doesn't differentiate between an empty typesupport packages list and no list, so `rmw_implementation` needs to list at least one typesupport package (for C, but do it for C++ too).

This is a weird workaround, but `rmw_implementation` is already a special case, as seen in `get_available_rmw_implementations()`, so it's probably not worth modifying `get_rmw_typesupport()` to differentiate between an empty list and no list. Just add a comment here to explain this.