### PR TITLE
Add regression test for take_event/on_sample_lost lock-order inversion

### DIFF
--- a/test_rmw_implementation/CMakeLists.txt
+++ b/test_rmw_implementation/CMakeLists.txt
@@ -196,6 +196,15 @@ if(BUILD_TESTING)
     test_msgs::test_msgs
   )
 
+  ament_add_gtest_executable(test_event_message_lost_deadlock
+    test/test_event_message_lost_deadlock.cpp
+  )
+  target_link_libraries(test_event_message_lost_deadlock
+    rmw::rmw
+    rmw_implementation::rmw_implementation
+    test_msgs::test_msgs
+  )
+
   function(test_api)
     message(STATUS "Creating API tests for '${rmw_implementation}'")
     set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
@@ -297,6 +306,17 @@ if(BUILD_TESTING)
       TEST_NAME test_event${target_suffix}
       ENV
         ${rmw_implementation_env_var}
+    )
+
+    # Reproduces an AB-BA lock-order inversion between rmw_take_event(MESSAGE_LOST)
+    # and on_sample_lost. Requires real SAMPLE_LOST, so intra-process delivery is
+    # disabled via the profile below (Fast DDS only; ignored by other implementations).
+    ament_add_ros_isolated_gtest_test(test_event_message_lost_deadlock
+      TEST_NAME test_event_message_lost_deadlock${target_suffix}
+      TIMEOUT 60
+      ENV
+        ${rmw_implementation_env_var}
+        FASTRTPS_DEFAULT_PROFILES_FILE=${CMAKE_CURRENT_SOURCE_DIR}/test/no_intraprocess_profile.xml
     )
   endfunction()
 

--- a/test_rmw_implementation/CMakeLists.txt
+++ b/test_rmw_implementation/CMakeLists.txt
@@ -309,15 +309,21 @@ if(BUILD_TESTING)
     )
 
     # Reproduces an AB-BA lock-order inversion between rmw_take_event(MESSAGE_LOST)
-    # and on_sample_lost. Requires real SAMPLE_LOST, so intra-process delivery is
-    # disabled via the profile below (Fast DDS only; ignored by other implementations).
-    ament_add_ros_isolated_gtest_test(test_event_message_lost_deadlock
-      TEST_NAME test_event_message_lost_deadlock${target_suffix}
-      TIMEOUT 60
-      ENV
-        ${rmw_implementation_env_var}
-        FASTRTPS_DEFAULT_PROFILES_FILE=${CMAKE_CURRENT_SOURCE_DIR}/test/no_intraprocess_profile.xml
-    )
+    # and on_sample_lost. This is specific to rmw_fastrtps: it relies on disabling
+    # intra-process delivery (via the Fast DDS profile below, a no-op for other
+    # implementations) to force real SAMPLE_LOST. Other implementations do not
+    # reliably produce SAMPLE_LOST for this pattern, so registering it for them only
+    # yields false failures; restrict registration to the fastrtps variants. (The test
+    # itself also skips cleanly if no loss is generated.)
+    if(rmw_implementation MATCHES "fastrtps")
+      ament_add_ros_isolated_gtest_test(test_event_message_lost_deadlock
+        TEST_NAME test_event_message_lost_deadlock${target_suffix}
+        TIMEOUT 60
+        ENV
+          ${rmw_implementation_env_var}
+          FASTRTPS_DEFAULT_PROFILES_FILE=${CMAKE_CURRENT_SOURCE_DIR}/test/no_intraprocess_profile.xml
+      )
+    endif()
   endfunction()
 
   call_for_each_rmw_implementation(test_api)

--- a/test_rmw_implementation/test/no_intraprocess_profile.xml
+++ b/test_rmw_implementation/test/no_intraprocess_profile.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  Disables Fast DDS intra-process delivery so that a same-process publisher/subscriber
+  pair actually goes through the RTPS path and can produce SAMPLE_LOST. Required by
+  test_event_message_lost_deadlock to exercise the on_sample_lost receive path.
+  Ignored by non-Fast DDS implementations.
+-->
+<dds xmlns="http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles">
+  <library_settings>
+    <intraprocess_delivery>OFF</intraprocess_delivery>
+  </library_settings>
+</dds>

--- a/test_rmw_implementation/test/test_event_message_lost_deadlock.cpp
+++ b/test_rmw_implementation/test/test_event_message_lost_deadlock.cpp
@@ -1,0 +1,218 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Regression test for an AB-BA lock-order inversion in the subscription
+// QoS-event path.
+//
+// Two mutexes are involved, per subscription:
+//   R = the DataReader's internal mutex
+//   E = the rmw subscription event mutex
+//
+//   * Executor side (the take loop below):
+//       rmw_take_event(MESSAGE_LOST) locks E, then queries the reader's
+//       sample-lost status, which locks R.                          (E -> R)
+//
+//   * DDS receive side (driven by real sample loss):
+//       the reader holds R while delivering on_sample_lost, which calls back
+//       into rmw and locks E.                                       (R -> E)
+//
+// Run concurrently with actual SAMPLE_LOST traffic, these orderings deadlock on
+// an affected implementation.
+//
+// To exercise it, all three must hold:
+//   1. The MESSAGE_LOST event callback is armed via rmw_event_set_callback()
+//      (this is what an events-driven executor does; it makes the implementation
+//      deliver on_sample_lost under the reader mutex -- the R->E edge).
+//   2. Real SAMPLE_LOST occurs. The CMake registration sets a profile that
+//      disables intra-process delivery for rmw_fastrtps; intra-process delivery
+//      hands samples over inline and never loses them. If no loss is generated
+//      the test reports "scenario not exercised" rather than a misleading pass.
+//   3. The take loop and the publisher flood run concurrently (done below).
+//
+// On an affected implementation the take loop wedges and the watchdog fails the
+// test; on a fixed implementation the take loop keeps progressing and it passes.
+//
+// For deterministic detection, build the rmw implementation with ThreadSanitizer;
+// TSAN reports the inversion the first time both orderings are observed.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <thread>
+
+#include "rcutils/allocator.h"
+#include "rcutils/strdup.h"
+
+#include "rmw/error_handling.h"
+#include "rmw/event.h"
+#include "rmw/rmw.h"
+
+#include "test_msgs/msg/basic_types.h"
+
+namespace
+{
+constexpr std::chrono::seconds kMaxRunTime{20};       // overall cap
+constexpr std::chrono::seconds kStallWindow{3};       // no take progress => deadlock
+constexpr std::chrono::milliseconds kDiscovery{500};  // endpoint matching
+}  // namespace
+
+class TestEventMessageLostDeadlock : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rcutils_allocator_t allocator = rcutils_get_default_allocator();
+    init_options = rmw_get_zero_initialized_init_options();
+    ASSERT_EQ(RMW_RET_OK, rmw_init_options_init(&init_options, allocator));
+    init_options.enclave = rcutils_strdup("/", allocator);
+    ASSERT_STREQ("/", init_options.enclave);
+    ASSERT_EQ(RMW_RET_OK, rmw_init(&init_options, &context));
+    node = rmw_create_node(&context, "test_event_message_lost_deadlock", "/");
+    ASSERT_NE(nullptr, node);
+  }
+
+  void TearDown() override
+  {
+    if (node) {
+      EXPECT_EQ(RMW_RET_OK, rmw_destroy_node(node));
+    }
+    EXPECT_EQ(RMW_RET_OK, rmw_shutdown(&context));
+    EXPECT_EQ(RMW_RET_OK, rmw_context_fini(&context));
+    EXPECT_EQ(RMW_RET_OK, rmw_init_options_fini(&init_options));
+  }
+
+  rmw_init_options_t init_options{rmw_get_zero_initialized_init_options()};
+  rmw_context_t context{rmw_get_zero_initialized_context()};
+  rmw_node_t * node{nullptr};
+  rmw_publisher_options_t pub_options = rmw_get_default_publisher_options();
+  rmw_subscription_options_t sub_options = rmw_get_default_subscription_options();
+  const rosidl_message_type_support_t * ts =
+    ROSIDL_GET_MSG_TYPE_SUPPORT(test_msgs, msg, BasicTypes);
+  const char * topic_name = "/message_lost_deadlock";
+};
+
+TEST_F(TestEventMessageLostDeadlock, take_event_does_not_deadlock_with_on_sample_lost)
+{
+  // Shallow, best-effort QoS so a non-draining reader under a publisher flood drops
+  // samples and generates SAMPLE_LOST.
+  rmw_qos_profile_t qos = rmw_qos_profile_default;
+  qos.history = RMW_QOS_POLICY_HISTORY_KEEP_LAST;
+  qos.depth = 1;
+  qos.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+
+  rmw_publisher_t * pub = rmw_create_publisher(node, ts, topic_name, &qos, &pub_options);
+  ASSERT_NE(nullptr, pub) << rmw_get_error_string().str;
+  rmw_subscription_t * sub = rmw_create_subscription(node, ts, topic_name, &qos, &sub_options);
+  ASSERT_NE(nullptr, sub) << rmw_get_error_string().str;
+
+  std::this_thread::sleep_for(kDiscovery);  // let endpoints match
+
+  // Arm the MESSAGE_LOST event callback so the implementation delivers on_sample_lost
+  // under the reader mutex -- the R->E edge of the inversion.
+  rmw_event_t event{rmw_get_zero_initialized_event()};
+  ASSERT_EQ(RMW_RET_OK, rmw_subscription_event_init(&event, sub, RMW_EVENT_MESSAGE_LOST))
+    << rmw_get_error_string().str;
+
+  std::atomic<uint64_t> events_seen{0};
+  rmw_event_callback_t cb = [](const void * user_data, size_t /*number_of_events*/) {
+      auto * counter = static_cast<std::atomic<uint64_t> *>(const_cast<void *>(user_data));
+      counter->fetch_add(1, std::memory_order_relaxed);
+    };
+  ASSERT_EQ(RMW_RET_OK, rmw_event_set_callback(&event, cb, &events_seen))
+    << rmw_get_error_string().str;
+
+  std::atomic<bool> stop{false};
+  std::atomic<uint64_t> take_iters{0};
+
+  // Publisher flood: messages are never taken on the reader, so the depth-1 history
+  // overruns and SAMPLE_LOST fires on the receive thread (which holds the reader mutex
+  // when it invokes on_sample_lost).
+  std::thread flood([&]() {
+      test_msgs__msg__BasicTypes msg;
+      test_msgs__msg__BasicTypes__init(&msg);
+      while (!stop.load(std::memory_order_relaxed)) {
+        (void)rmw_publish(pub, &msg, nullptr);
+      }
+      test_msgs__msg__BasicTypes__fini(&msg);
+    });
+
+  // take_event loop: take_event locks the event mutex, then queries the reader's
+  // sample-lost status (reader mutex) -- the E->R edge.
+  std::thread taker([&]() {
+      rmw_message_lost_status_t status;
+      bool taken = false;
+      while (!stop.load(std::memory_order_relaxed)) {
+        (void)rmw_take_event(&event, &status, &taken);
+        take_iters.fetch_add(1, std::memory_order_relaxed);
+      }
+    });
+
+  // Watchdog: the deadlock wedges the taker (stuck acquiring the reader mutex), so its
+  // iteration counter freezes while loss continues. The best-effort publisher keeps
+  // running regardless, so we watch the taker specifically.
+  const auto start = std::chrono::steady_clock::now();
+  auto last_progress = start;
+  uint64_t last_take = 0;
+  bool deadlocked = false;
+
+  while (std::chrono::steady_clock::now() - start < kMaxRunTime) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    const uint64_t now_take = take_iters.load(std::memory_order_relaxed);
+    if (now_take != last_take) {
+      last_take = now_take;
+      last_progress = std::chrono::steady_clock::now();
+      continue;
+    }
+    // No take progress. Only call it a deadlock once loss has actually been generated,
+    // i.e. the R->E edge is genuinely being exercised.
+    if (events_seen.load(std::memory_order_relaxed) > 0 &&
+      std::chrono::steady_clock::now() - last_progress > kStallWindow)
+    {
+      deadlocked = true;
+      break;
+    }
+  }
+
+  stop.store(true, std::memory_order_relaxed);
+
+  if (deadlocked) {
+    // The workers are wedged on the inverted mutexes and cannot be joined or recovered
+    // (TearDown would also wedge destroying DDS entities). Detach and terminate non-zero
+    // so the test is recorded as a failure instead of hanging.
+    flood.detach();
+    taker.detach();
+    std::cerr
+      << "\nDEADLOCK DETECTED: rmw_take_event(MESSAGE_LOST) (event mutex -> reader mutex) "
+         "deadlocked against on_sample_lost (reader mutex -> event mutex).\n"
+      << "  take_event iterations before stall: " << take_iters.load() << "\n"
+      << "  sample-lost events observed: " << events_seen.load() << "\n";
+    std::quick_exit(1);
+  }
+
+  flood.join();
+  taker.join();
+
+  EXPECT_EQ(RMW_RET_OK, rmw_event_fini(&event));
+  EXPECT_EQ(RMW_RET_OK, rmw_destroy_subscription(node, sub));
+  EXPECT_EQ(RMW_RET_OK, rmw_destroy_publisher(node, pub));
+
+  // Guard against a misleading pass: if no loss was ever generated the R->E edge never
+  // ran. Most commonly this means intra-process delivery was left enabled.
+  EXPECT_GT(events_seen.load(), 0u)
+    << "No SAMPLE_LOST was generated, so the lock-order inversion was not exercised. "
+       "Ensure intra-process delivery is disabled (see the profile in the CMake env).";
+}

--- a/test_rmw_implementation/test/test_event_message_lost_deadlock.cpp
+++ b/test_rmw_implementation/test/test_event_message_lost_deadlock.cpp
@@ -210,9 +210,14 @@ TEST_F(TestEventMessageLostDeadlock, take_event_does_not_deadlock_with_on_sample
   EXPECT_EQ(RMW_RET_OK, rmw_destroy_subscription(node, sub));
   EXPECT_EQ(RMW_RET_OK, rmw_destroy_publisher(node, pub));
 
-  // Guard against a misleading pass: if no loss was ever generated the R->E edge never
-  // ran. Most commonly this means intra-process delivery was left enabled.
-  EXPECT_GT(events_seen.load(), 0u)
-    << "No SAMPLE_LOST was generated, so the lock-order inversion was not exercised. "
-       "Ensure intra-process delivery is disabled (see the profile in the CMake env).";
+  // If no loss was ever generated, the R->E edge never ran, so the scenario was not
+  // exercised and "no deadlock" proves nothing. This happens when intra-process delivery
+  // was not disabled, or on an implementation that does not produce SAMPLE_LOST for a
+  // depth-1 best-effort reader that never takes. Skip cleanly rather than reporting a
+  // misleading pass or a failure unrelated to any deadlock.
+  if (events_seen.load() == 0u) {
+    GTEST_SKIP()
+      << "No SAMPLE_LOST was generated, so the lock-order inversion was not exercised. "
+         "Ensure intra-process delivery is disabled (see the profile in the CMake env).";
+  }
 }

--- a/test_rmw_implementation/test/test_event_message_lost_deadlock.cpp
+++ b/test_rmw_implementation/test/test_event_message_lost_deadlock.cpp
@@ -197,7 +197,7 @@ TEST_F(TestEventMessageLostDeadlock, take_event_does_not_deadlock_with_on_sample
     taker.detach();
     std::cerr
       << "\nDEADLOCK DETECTED: rmw_take_event(MESSAGE_LOST) (event mutex -> reader mutex) "
-         "deadlocked against on_sample_lost (reader mutex -> event mutex).\n"
+      "deadlocked against on_sample_lost (reader mutex -> event mutex).\n"
       << "  take_event iterations before stall: " << take_iters.load() << "\n"
       << "  sample-lost events observed: " << events_seen.load() << "\n";
     std::quick_exit(1);
@@ -218,6 +218,6 @@ TEST_F(TestEventMessageLostDeadlock, take_event_does_not_deadlock_with_on_sample
   if (events_seen.load() == 0u) {
     GTEST_SKIP()
       << "No SAMPLE_LOST was generated, so the lock-order inversion was not exercised. "
-         "Ensure intra-process delivery is disabled (see the profile in the CMake env).";
+      "Ensure intra-process delivery is disabled (see the profile in the CMake env).";
   }
 }


### PR DESCRIPTION
## Description

Adds `test_event_message_lost_deadlock`, which reproduces an AB-BA lock-order inversion in the `rmw_fastrtps` subscription QoS-event path:

  * Executor side: `rmw_take_event(MESSAGE_LOST)` locks the rmw event mutex, then queries the reader's sample-lost status, which locks the  DataReader mutex. (E -> R)
  * DDS receive side: the reader holds its mutex while delivering on_sample_lost, which calls back into rmw and locks the event mutex. (R -> E)

Run concurrently under real `SAMPLE_LOST` these orderings deadlock. The test arms the `MESSAGE_LOST` callback (the events-executor path), floods a depth-1 best-effort subscription to force `SAMPLE_LOST`, and runs a `rmw_take_event` loop concurrently; a watchdog reports the deadlock if the take loop stalls. An `events_seen > 0` guard rejects a misleading pass when no loss was generated.

Requires intra-process delivery to be disabled, so the test is registered with a Fast DDS profile (`no_intraprocess_profile.xml`) that sets `intraprocess_delivery` OFF; intra-process delivery hands samples over inline and never loses them. Registered only for the fastrtps variants.

This is the event-path analog of the already-fixed data-path inversion (https://github.com/ros2/rmw_fastrtps/pull/657). The fix lives in `ros2/rmw_fastrtps` (`take_event` / `set_on_new_event_callback` no longer hold the event mutex across the reader status query): unpatched rolling deadlocks (test fails / times out), the fixed branch passes.

This test is expected to fail until https://github.com/ros2/rmw_fastrtps/pull/890 is merged.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

This test was generated using Claude Opus 4.8 (1M context).

### Additional Information

Here's the relevant output of running the test with TSAN enabled without the fix incorporated:

```
WARNING: ThreadSanitizer: lock-order-inversion (potential deadlock) (pid=1759)
  Cycle in lock order graph: M0 (0x725c00002868) => M1 (0x725800003d88) => M0

  Mutex M1 acquired here while holding mutex M0 in main thread:
    #0 pthread_mutex_lock ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1341 (libtsan.so.2+0x59a13) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 eprosima::fastdds::dds::DataReaderImpl::get_sample_lost_status(eprosima::fastdds::dds::BaseStatus&) <null> (libfastdds.so.3.6+0x2f5e8f) (BuildId: 4876362f9e32f84c8de4cabe21943a7e824e50df)
    #2 rmw_fastrtps_shared_cpp::__rmw_event_set_callback(rmw_event_s*, void (*)(void const*, unsigned long), void const*) /root/ws/src/rmw_fastrtps/rmw_fastrtps_shared_cpp/src/rmw_event.cpp:160 (librmw_fastrtps_shared_cpp.so+0x7ea51) (BuildId: bf3e92c2fa8c596c57cb845fbc19a000efc9cd77)
    #3 rmw_event_set_callback /root/ws/src/rmw_fastrtps/rmw_fastrtps_cpp/src/rmw_event.cpp:59 (librmw_fastrtps_cpp.so+0x5c605) (BuildId: 9b3ff1ce4ed3e15ab82d0d4484b7111af698f51f)
    #4 TestEventMessageLostDeadlock_take_event_does_not_deadlock_with_on_sample_lost_Test::TestBody() /root/ws/src/rmw_implementation/test_rmw_implementation/test/test_event_message_lost_deadlock.cpp:135 (test_event_message_lost_deadlock+0x11c76) (BuildId: 585a1db1b0a675f95e137685aac2f5668e8228b2)
    #5 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) <null> (test_event_message_lost_deadlock+0x50dae) (BuildId: 585a1db1b0a675f95e137685aac2f5668e8228b2)

  Mutex M0 previously acquired by the same thread here:
    #0 pthread_mutex_lock ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1341 (libtsan.so.2+0x59a13) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 __gthread_mutex_lock /usr/include/x86_64-linux-gnu/c++/13/bits/gthr-default.h:749 (librmw_fastrtps_shared_cpp.so+0x4db11) (BuildId: bf3e92c2fa8c596c57cb845fbc19a000efc9cd77)
    #2 std::mutex::lock() /usr/include/c++/13/bits/std_mutex.h:113 (librmw_fastrtps_shared_cpp.so+0x4db11)
    #3 std::unique_lock<std::mutex>::lock() /usr/include/c++/13/bits/unique_lock.h:141 (librmw_fastrtps_shared_cpp.so+0x4db11)
    #4 std::unique_lock<std::mutex>::unique_lock(std::mutex&) /usr/include/c++/13/bits/unique_lock.h:71 (librmw_fastrtps_shared_cpp.so+0x4db11)
    #5 rcpputils::unique_lock<std::mutex>::unique_lock(std::mutex&) /opt/ros/rolling/include/rcpputils/rcpputils/unique_lock.hpp:35 (librmw_fastrtps_shared_cpp.so+0x4db11)
    #6 RMWSubscriptionEvent::set_on_new_event_callback(rmw_event_type_e, void const*, void (*)(void const*, unsigned long)) /root/ws/src/rmw_fastrtps/rmw_fastrtps_shared_cpp/src/custom_subscriber_info.cpp:242 (librmw_fastrtps_shared_cpp.so+0x4db11)
    #7 rmw_fastrtps_shared_cpp::__rmw_event_set_callback(rmw_event_s*, void (*)(void const*, unsigned long), void const*) /root/ws/src/rmw_fastrtps/rmw_fastrtps_shared_cpp/src/rmw_event.cpp:160 (librmw_fastrtps_shared_cpp.so+0x7ea51) (BuildId: bf3e92c2fa8c596c57cb845fbc19a000efc9cd77)
    #8 rmw_event_set_callback /root/ws/src/rmw_fastrtps/rmw_fastrtps_cpp/src/rmw_event.cpp:59 (librmw_fastrtps_cpp.so+0x5c605) (BuildId: 9b3ff1ce4ed3e15ab82d0d4484b7111af698f51f)
    #9 TestEventMessageLostDeadlock_take_event_does_not_deadlock_with_on_sample_lost_Test::TestBody() /root/ws/src/rmw_implementation/test_rmw_implementation/test/test_event_message_lost_deadlock.cpp:135 (test_event_message_lost_deadlock+0x11c76) (BuildId: 585a1db1b0a675f95e137685aac2f5668e8228b2)
    #10 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) <null> (test_event_message_lost_deadlock+0x50dae) (BuildId: 585a1db1b0a675f95e137685aac2f5668e8228b2)

  Mutex M0 acquired here while holding mutex M1 in thread T4:
    #0 pthread_mutex_lock ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1341 (libtsan.so.2+0x59a13) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 __gthread_mutex_lock /usr/include/x86_64-linux-gnu/c++/13/bits/gthr-default.h:749 (librmw_fastrtps_shared_cpp.so+0x4c95f) (BuildId: bf3e92c2fa8c596c57cb845fbc19a000efc9cd77)
    #2 std::mutex::lock() /usr/include/c++/13/bits/std_mutex.h:113 (librmw_fastrtps_shared_cpp.so+0x4c95f)
    #3 std::lock_guard<std::mutex>::lock_guard(std::mutex&) /usr/include/c++/13/bits/std_mutex.h:249 (librmw_fastrtps_shared_cpp.so+0x4c95f)
    #4 RMWSubscriptionEvent::update_sample_lost(unsigned int, unsigned int) /root/ws/src/rmw_fastrtps/rmw_fastrtps_shared_cpp/src/custom_subscriber_info.cpp:449 (librmw_fastrtps_shared_cpp.so+0x4c95f)
    #5 CustomDataReaderListener::on_sample_lost(eprosima::fastdds::dds::DataReader*, eprosima::fastdds::dds::BaseStatus const&) /root/ws/src/rmw_fastrtps/rmw_fastrtps_shared_cpp/src/custom_subscriber_info.cpp:97 (librmw_fastrtps_shared_cpp.so+0x4ca40) (BuildId: bf3e92c2fa8c596c57cb845fbc19a000efc9cd77)
    #6 eprosima::fastdds::dds::DataReaderImpl::InnerDataReaderListener::on_sample_lost(eprosima::fastdds::rtps::RTPSReader*, int) <null> (libfastdds.so.3.6+0x2f84de) (BuildId: 4876362f9e32f84c8de4cabe21943a7e824e50df)

  Mutex M1 previously acquired by the same thread here:
    #0 pthread_mutex_lock ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1341 (libtsan.so.2+0x59a13) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 eprosima::fastdds::rtps::StatelessReader::process_data_msg(eprosima::fastdds::rtps::CacheChange_t*) <null> (libfastdds.so.3.6+0x5867d6) (BuildId: 4876362f9e32f84c8de4cabe21943a7e824e50df)

  Thread T4 'dds.shm.7411' (tid=1769, running) created by main thread at:
    #0 pthread_create ../../../../src/libsanitizer/tsan/tsan_interceptors_posix.cpp:1022 (libtsan.so.2+0x5ac1a) (BuildId: 2a13a7710e361d06f7babbea53065ca2be93f738)
    #1 eprosima::thread::start_thread_impl(int, void* (*)(void*), void*) <null> (libfastdds.so.3.6+0x60633a) (BuildId: 4876362f9e32f84c8de4cabe21943a7e824e50df)
    #2 init_context_impl /root/ws/src/rmw_fastrtps/rmw_fastrtps_cpp/src/init_rmw_context_impl.cpp:82 (librmw_fastrtps_cpp.so+0x38090) (BuildId: 9b3ff1ce4ed3e15ab82d0d4484b7111af698f51f)
    #3 rmw_fastrtps_cpp::increment_context_impl_ref_count(rmw_context_s*) /root/ws/src/rmw_fastrtps/rmw_fastrtps_cpp/src/init_rmw_context_impl.cpp:244 (librmw_fastrtps_cpp.so+0x39597) (BuildId: 9b3ff1ce4ed3e15ab82d0d4484b7111af698f51f)
    #4 rmw_create_node /root/ws/src/rmw_fastrtps/rmw_fastrtps_cpp/src/rmw_node.cpp:60 (librmw_fastrtps_cpp.so+0x5e70f) (BuildId: 9b3ff1ce4ed3e15ab82d0d4484b7111af698f51f)
    #5 TestEventMessageLostDeadlock::SetUp() /root/ws/src/rmw_implementation/test_rmw_implementation/test/test_event_message_lost_deadlock.cpp:84 (test_event_message_lost_deadlock+0x1713a) (BuildId: 585a1db1b0a675f95e137685aac2f5668e8228b2)
    #6 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) <null> (test_event_message_lost_deadlock+0x50dae) (BuildId: 585a1db1b0a675f95e137685aac2f5668e8228b2)
```
