### PR TITLE
Clean up QoS test entities

### DIFF
--- a/test_rmw_implementation/test/test_client.cpp
+++ b/test_rmw_implementation/test/test_client.cpp
@@ -415,6 +415,7 @@ TEST_F(TestClient, check_qos) {
 
   rmw_client_t * client =
     rmw_create_client(node, ts, service_name, &qos_profile);
+  ASSERT_NE(nullptr, client) << rmw_get_error_string().str;
 
   rmw_qos_profile_t actual_rp_qos;
   rmw_ret_t ret = rmw_client_request_publisher_get_actual_qos(
@@ -450,4 +451,7 @@ TEST_F(TestClient, check_qos) {
   EXPECT_EQ(actual_rs_qos.liveliness_lease_duration.sec, qos_profile.liveliness_lease_duration.sec);
   EXPECT_EQ(
     actual_rs_qos.liveliness_lease_duration.nsec, qos_profile.liveliness_lease_duration.nsec);
+
+  ret = rmw_destroy_client(node, client);
+  EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
 }

--- a/test_rmw_implementation/test/test_service.cpp
+++ b/test_rmw_implementation/test/test_service.cpp
@@ -522,6 +522,7 @@ TEST_F(TestService, check_qos) {
 
   rmw_service_t * srv =
     rmw_create_service(node, ts, service_name, &qos_profile);
+  ASSERT_NE(nullptr, srv) << rmw_get_error_string().str;
 
   rmw_qos_profile_t actual_rp_qos;
   rmw_ret_t ret = rmw_service_response_publisher_get_actual_qos(
@@ -558,4 +559,7 @@ TEST_F(TestService, check_qos) {
   EXPECT_EQ(actual_rs_qos.liveliness_lease_duration.sec, qos_profile.liveliness_lease_duration.sec);
   EXPECT_EQ(
     actual_rs_qos.liveliness_lease_duration.nsec, qos_profile.liveliness_lease_duration.nsec);
+
+  ret = rmw_destroy_service(node, srv);
+  EXPECT_EQ(RMW_RET_OK, ret) << rmw_get_error_string().str;
 }


### PR DESCRIPTION
## Description

The client and service QoS tests violate the `rmw_destroy_node()` precondition (see [rmw.h#L184-L188](https://github.com/ros2/rmw/blob/rolling/rmw/include/rmw/rmw.h#L184-L188)) by leaving entities active, causing failures in RMW implementations that enforce entity cleanup.

This PR adds explicit creation verification checks as well as correctly destroying entities after QoS checks are complete.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
